### PR TITLE
Fix blob URL leak and dead code in library manager

### DIFF
--- a/src/main/nyancad/mosaic/libman.cljc
+++ b/src/main/nyancad/mosaic/libman.cljc
@@ -7,14 +7,14 @@
             [reagent.core :as r]
             [reagent.dom :as rd]
             #?@(:vscode [[nyancad.mosaic.libman.platform-vscode
-                           :refer [modeldb syncactive remotemodeldb remote-search-loading
+                           :refer [modeldb syncactive
                                    preview-url get-preview search-remote-models
-                                   replicate-model replicate-filtered-models
+                                   remote-models-section
                                    edit-url import-ports workspace-selector init-extra!]]]
                 :cljs    [[nyancad.mosaic.libman.platform-web
-                           :refer [modeldb syncactive remotemodeldb remote-search-loading
+                           :refer [modeldb syncactive
                                    preview-url get-preview search-remote-models
-                                   replicate-model replicate-filtered-models
+                                   remote-models-section
                                    edit-url import-ports workspace-selector init-extra!]]])
             [nyancad.mosaic.common :as cm]))
 
@@ -78,32 +78,8 @@
        (fn [model-id]
          #(model-context-menu % db model-id))]]
 
-     ;; Available models section (hidden when no remote DB)
-     (when (or (seq @remotemodeldb) @remote-search-loading)
-       [:div.available-section
-        [:div.section-header-with-button
-         [:h4.section-header "Available"]
-         (when (seq @remotemodeldb)
-           [:button.download-btn.all {:on-click #(replicate-filtered-models @selcat @filter-text)
-                                      :title "Download all matching models"}
-            [cm/download] "Download All"])]
-        (cond
-          @remote-search-loading
-          [:div.loading-spinner "Loading..."]
-
-          (seq @remotemodeldb)
-          [:div.remote-models
-           (doall (for [[model-id model] @remotemodeldb
-                        :let [schem? (not (:templates model))
-                              icon (if schem? cm/schemmodel cm/codemodel)]]
-                    [:label.remote-model {:key model-id}
-                     [icon] " " (get model :name model-id)
-                     [:button.download-btn {:on-click #(replicate-model model-id)
-                                            :title "Download this model"}
-                      [cm/download]]]))]
-
-          :else
-          [:div.empty "No remote models found"])])]))
+     ;; Available models section (platform-specific: web shows remote DB, VS Code is no-op)
+     [remote-models-section selcat filter-text]]))
 
 (defn port-editor [cell side]
   (let [path [:ports side]]

--- a/src/main/nyancad/mosaic/libman/platform_vscode.cljs
+++ b/src/main/nyancad/mosaic/libman/platform_vscode.cljs
@@ -54,12 +54,18 @@
     (go
       (let [bare-id (cm/bare-id new-model)
             svg-content (<! (send-request! (str bare-id ".svg")))]
+        (when @preview-url (js/URL.revokeObjectURL @preview-url))
         (if svg-content
           (let [blob (js/Blob. #js[svg-content] #js{:type "image/svg+xml"})
                 url (js/URL.createObjectURL blob)]
             (reset! preview-url url))
           (reset! preview-url nil))))
-    (reset! preview-url nil)))
+    (do (when @preview-url (js/URL.revokeObjectURL @preview-url))
+        (reset! preview-url nil))))
+
+;; --- Remote models section (stub — no remote DB in VS Code) ---
+
+(defn remote-models-section [_selcat _filter-text] nil)
 
 ;; --- Remote search (stubs — no remote DB in VS Code) ---
 

--- a/src/main/nyancad/mosaic/libman/platform_web.cljs
+++ b/src/main/nyancad/mosaic/libman/platform_web.cljs
@@ -48,10 +48,12 @@
                                       :descending true
                                       :limit 1}))
             rows (json->clj (.-rows docs))]
+        (when @preview-url (js/URL.revokeObjectURL @preview-url))
         (if-let [preview-attachment (get-in rows [0 :doc :_attachments :preview.svg :data])]
           (reset! preview-url (js/URL.createObjectURL preview-attachment))
           (reset! preview-url nil))))
-    (reset! preview-url nil)))
+    (do (when @preview-url (js/URL.revokeObjectURL @preview-url))
+        (reset! preview-url nil))))
 
 ;; --- Remote search ---
 
@@ -107,6 +109,36 @@
     (println selector)
     (.on replication "complete" #(js/console.log "Filtered models replicated"))
     (.on replication "error" #(js/console.error "Replication error:" %))))
+
+;; --- Remote models section ---
+
+(defn remote-models-section
+  "Reagent component for the 'Available' remote models section."
+  [selcat filter-text]
+  [:div.available-section
+   [:div.section-header-with-button
+    [:h4.section-header "Available"]
+    (when (seq @remotemodeldb)
+      [:button.download-btn.all {:on-click #(replicate-filtered-models @selcat @filter-text)
+                                  :title "Download all matching models"}
+       [cm/download] "Download All"])]
+   (cond
+     @remote-search-loading
+     [:div.loading-spinner "Loading..."]
+
+     (seq @remotemodeldb)
+     [:div.remote-models
+      (doall (for [[model-id model] @remotemodeldb
+                    :let [schem? (not (:templates model))
+                          icon (if schem? cm/schemmodel cm/codemodel)]]
+                [:label.remote-model {:key model-id}
+                 [icon] " " (get model :name model-id)
+                 [:button.download-btn {:on-click #(replicate-model model-id)
+                                        :title "Download this model"}
+                  [cm/download]]]))]
+
+     :else
+     [:div.empty "No remote models found"])])
 
 ;; --- Edit & Import ---
 


### PR DESCRIPTION
## Summary
- **#121**: Revoke previous blob URL before creating new ones in `get-preview` on both web and VS Code platforms, preventing a leak per model selection
- **#122**: Extract remote models "Available" section into a platform component (`remote-models-section`). Web renders loading/results/empty states; VS Code returns nil. Fixes the unreachable `:else` branch and restores "No remote models found" on web when search returns empty

Closes #121
Closes #122

## Test plan
- [x] Web: switch between models in library manager, verify no blob URL accumulation in devtools
- [ ] Web: search for a term with no matching remote models, verify "No remote models found" appears
- [ ] VS Code: verify library manager renders without the "Available" section
- [ ] Both `frontend` and `vscode-webview` compile with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)