### PR TITLE
Handle toolbar overflow with CSS dropdown menus

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -685,7 +685,7 @@ html {
     background-color: var(--color-surface);
     box-shadow: 0px 0px 8px #00000008;
     border: 0.5px solid var(--color-border-light);
-    z-index: 1;
+    z-index: 2;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -698,7 +698,24 @@ html {
 .mosaic-container .menu .primary {
     display: flex;
     justify-content: flex-start;
-    flex-wrap: wrap;
+}
+
+.mosaic-container .menu .toolbar-group {
+    display: contents;
+}
+
+/* Separator between groups (replaces span.sep) */
+.mosaic-container .menu .toolbar-group + .toolbar-group > :first-child {
+    margin-left: 1em;
+    position: relative;
+}
+.mosaic-container .menu .toolbar-group + .toolbar-group > :first-child::before {
+    content: '';
+    position: absolute;
+    left: -0.75em;
+    top: 0;
+    bottom: 0;
+    border-left: 1px solid var(--color-border);
 }
 
 .mosaic-container .menu .secondary {
@@ -792,11 +809,6 @@ html {
     fill: var(--color-text);
 }
 
-.mosaic-container .chrome span.sep {
-    border-right: 1px solid var(--color-border);
-    padding: 0;
-    margin: 0.75em 0.5em;
-}
 
 .mosaic-container .chrome a:hover,
 .mosaic-container .chrome button:hover {
@@ -946,6 +958,63 @@ g.toolstaging g.device {
 @media (hover: none) {
     .device g.toolstaging {
         display: none;
+    }
+}
+
+/* Narrow + mouse: toolbar groups collapse to one-button dropdowns */
+@media (max-width: 1400px) and (hover: hover) {
+    .mosaic-container .menu .primary {
+        height: calc(1em + 1em + 1.5em);
+        overflow: visible;
+        align-items: flex-start;
+    }
+
+    .mosaic-container .menu .toolbar-group {
+        display: flex;
+        flex-direction: column;
+        max-height: calc(1em + 1em + 1.5em);
+        overflow: hidden;
+    }
+
+    .mosaic-container .menu .toolbar-group > * {
+        flex-shrink: 0;
+    }
+
+    .mosaic-container .menu .toolbar-group:hover {
+        max-height: 500px;
+        z-index: 10;
+        background: var(--color-surface);
+        border: 0.5px solid var(--color-border-light);
+        border-radius: 5px;
+        box-shadow: 0px 0px 8px #0000001a;
+    }
+
+    /* Active tool floats to top of collapsed group */
+    .mosaic-container .tools-group input[type=radio]:checked + label {
+        order: -1;
+    }
+
+    /* Remove group separators in collapsed mode */
+    .mosaic-container .menu .toolbar-group + .toolbar-group > :first-child {
+        margin-left: 0.5em;
+    }
+    .mosaic-container .menu .toolbar-group + .toolbar-group > :first-child::before {
+        display: none;
+    }
+}
+
+/* Narrow + touch: toolbar scrolls horizontally */
+@media (max-width: 1400px) and (hover: none) {
+    .mosaic-container .menu .primary {
+        overflow-x: auto;
+        flex-shrink: 1;
+        min-width: 0;
+    }
+
+    .mosaic-container .menu .status,
+    .mosaic-container .menu .secondary {
+        flex-shrink: 0;
+        white-space: nowrap;
     }
 }
 

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -2049,52 +2049,53 @@
 (defn menu-items []
   [:<>
    [:div.primary
-    [cm/radiobuttons tool
-   ; label, key, title
-     [[[cm/cursor] ::cursor "Cursor [esc]"]
-      [[cm/wire] ::wire "Wire [w]"]
-      [[cm/eraser] ::eraser "Eraser [e]"]
-      [[cm/move] ::pan "Pan [space]"]
-      [[cm/probe] ::probe "Probe nodes in a connected simulator"]]
-     nil nil cancel]
-    [:span.sep]
-    [:a {:title "Rotate selected clockwise [s]"
-         :on-click (fn [_] (transform-selected #(.rotate % 90)))}
-     [cm/rotatecw]]
-    [:a {:title "Rotate selected counter-clockwise [shift+s]"
-         :on-click (fn [_] (transform-selected #(.rotate % -90)))}
-     [cm/rotateccw]]
-    [:a {:title "Mirror selected horizontal [shift+f]"
-         :on-click (fn [_] (transform-selected #(.flipY %)))}
-     [cm/mirror-horizontal]]
-    [:a {:title "Mirror selected vertical [f]"
-         :on-click (fn [_] (transform-selected #(.flipX %)))}
-     [cm/mirror-vertical]]
-    [:a {:title "Delete selected [del]"
-         :on-click (fn [_] (delete-selected))}
-     [cm/delete]]
-    [:a {:title "Copy selected [ctrl+c]"
-         :on-click (fn [_] (copy))}
-     [cm/copyi]]
-    [:a {:title "Cut selected [ctrl+x]"
-         :on-click (fn [_] (cut))}
-     [cm/cuti]]
-    [:a {:title "Paste [ctrl+v]"
-         :on-click (fn [_] (paste))}
-     [cm/pastei]]
-    [:span.sep]
-    [:a {:title "zoom in [scroll wheel/pinch]"
-         :on-click #(button-zoom -1)}
-     [cm/zoom-in]]
-    [:a {:title "zoom out [scroll wheel/pinch]"
-         :on-click #(button-zoom 1)}
-     [cm/zoom-out]]
-    [:a {:title "undo [ctrl+z]"
-         :on-click undo-schematic}
-     [cm/undoi]]
-    [:a {:title "redo [ctrl+shift+z]"
-         :on-click redo-schematic}
-     [cm/redoi]]]
+    [:div.toolbar-group.tools-group
+     [cm/radiobuttons tool
+    ; label, key, title
+      [[[cm/cursor] ::cursor "Cursor [esc]"]
+       [[cm/wire] ::wire "Wire [w]"]
+       [[cm/eraser] ::eraser "Eraser [e]"]
+       [[cm/move] ::pan "Pan [space]"]
+       [[cm/probe] ::probe "Probe nodes in a connected simulator"]]
+      nil nil cancel]]
+    [:div.toolbar-group
+     [:a {:title "Rotate selected clockwise [s]"
+          :on-click (fn [_] (transform-selected #(.rotate % 90)))}
+      [cm/rotatecw]]
+     [:a {:title "Rotate selected counter-clockwise [shift+s]"
+          :on-click (fn [_] (transform-selected #(.rotate % -90)))}
+      [cm/rotateccw]]
+     [:a {:title "Mirror selected horizontal [shift+f]"
+          :on-click (fn [_] (transform-selected #(.flipY %)))}
+      [cm/mirror-horizontal]]
+     [:a {:title "Mirror selected vertical [f]"
+          :on-click (fn [_] (transform-selected #(.flipX %)))}
+      [cm/mirror-vertical]]
+     [:a {:title "Delete selected [del]"
+          :on-click (fn [_] (delete-selected))}
+      [cm/delete]]
+     [:a {:title "Copy selected [ctrl+c]"
+          :on-click (fn [_] (copy))}
+      [cm/copyi]]
+     [:a {:title "Cut selected [ctrl+x]"
+          :on-click (fn [_] (cut))}
+      [cm/cuti]]
+     [:a {:title "Paste [ctrl+v]"
+          :on-click (fn [_] (paste))}
+      [cm/pastei]]]
+    [:div.toolbar-group
+     [:a {:title "zoom in [scroll wheel/pinch]"
+          :on-click #(button-zoom -1)}
+      [cm/zoom-in]]
+     [:a {:title "zoom out [scroll wheel/pinch]"
+          :on-click #(button-zoom 1)}
+      [cm/zoom-out]]
+     [:a {:title "undo [ctrl+z]"
+          :on-click undo-schematic}
+      [cm/undoi]]
+     [:a {:title "redo [ctrl+shift+z]"
+          :on-click redo-schematic}
+      [cm/redoi]]]]
    [:div.status
     [cm/renamable (r/cursor modeldb [(cm/model-key group) :name]) "Untitled"]
     (if @syncactive


### PR DESCRIPTION
## Summary
- Fixes #127 — toolbar no longer wraps into multiple rows on narrow windows
- **Mouse users (<1400px):** button groups collapse into hover-to-expand dropdowns, with the active tool shown first via flexbox `order`
- **Touch users (<1400px):** toolbar scrolls horizontally instead (avoids tap conflict)
- **Wide screens:** `display: contents` makes group wrappers invisible — zero layout change

## Test plan
- [ ] Wide window (>1400px): toolbar looks identical to before
- [ ] Narrow + mouse: groups collapse to one button each, hover expands
- [ ] Tools group: active tool appears first when collapsed
- [ ] Narrow + touch (Chrome DevTools → Rendering → emulate hover: none): horizontal scroll
- [ ] Both light and dark themes
- [ ] Separators between groups render correctly at all widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)