### PR TITLE
Better property annotation UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ Clojure docstrings come **before** the argument vector (unlike Python):
   (do-something arg1 arg2))
 ```
 
+Prefer `swap!` over `reset!` when the new value depends on the current atom state. The function passed to `swap!` should be idempotent, as it may be retried on conflict (especially with PouchDB-backed atoms). Avoid patterns like `(reset! atom (f @atom))` — use `(swap! atom f)` instead.
+
 ## Architecture Overview
 
 ### Module Structure

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -303,19 +303,26 @@ html {
 }
 
 /* Model field in device properties (text + browse button) */
-.mosaic-app .model-field {
+.mosaic-app .field-with-extra {
     display: flex;
     gap: 5px;
 }
 
-.mosaic-app .model-field input {
+.mosaic-app .field-with-extra > :first-child {
     flex: 1;
+    min-width: 0;
 }
 
-.mosaic-app .model-field button {
+.mosaic-app .field-with-extra button {
+    flex-shrink: 0;
     padding: 5px 10px;
     display: flex;
     align-items: center;
+}
+
+.mosaic-app button:disabled {
+    opacity: 0.3;
+    cursor: default;
 }
 
 /* library manager */
@@ -523,6 +530,9 @@ html {
 .mosaic-libman .properties label {
     grid-column: labels;
     grid-row: auto;
+    max-width: 10ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .mosaic-libman .properties input,
@@ -919,6 +929,9 @@ html {
 .mosaic-editor .properties label {
     grid-column: labels;
     grid-row: auto;
+    max-width: 10ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .mosaic-editor .properties input,
@@ -928,6 +941,18 @@ html {
     grid-row: auto;
     box-sizing: border-box;
     width: 100%;
+}
+
+.mosaic-editor .properties .template-header {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+
+.mosaic-editor .properties .field-with-extra {
+    grid-column: controls;
 }
 
 /* overflow handled by .mosaic-canvas in canvas base rules */
@@ -1973,13 +1998,20 @@ svg.eyesore {
 }
 
 .mosaic-app .properties .remove-btn:hover .bi-x-circle,
-.mosaic-app .properties .add-btn:hover .bi-plus-circle {
+.mosaic-app .properties .add-btn:hover .bi-plus-circle,
+.mosaic-app .properties .add-btn.active .bi-plus-circle {
     display: none;
 }
 
 .mosaic-app .properties .remove-btn:hover .bi-x-circle-fill,
-.mosaic-app .properties .add-btn:hover .bi-plus-circle-fill {
+.mosaic-app .properties .add-btn:hover .bi-plus-circle-fill,
+.mosaic-app .properties .add-btn.active .bi-plus-circle-fill {
     display: inline;
+}
+
+.mosaic-app .properties .add-btn.active {
+    background: var(--color-accent);
+    color: var(--color-accent-text);
 }
 
 /* Tag badges in model list */

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -59,32 +59,40 @@
 (declare recursive-editor dissjoc x-circle x-circle-fill plus-circle plus-circle-fill)
 
 (defn- leaf-editor
-  "Render a single leaf field: label + input/textarea/select/csv."
-  [{:keys [name tooltip type options placeholder default] :or {type :input}} cursor on-change]
+  "Render a single leaf field: label + input/textarea/select/csv.
+   Optional extra-el is injected inline next to the input (like the model selector button)."
+  [{:keys [name tooltip type options placeholder default] :or {type :input}} cursor on-change extra-el]
   (let [k (keyword name)
         ph (or placeholder "")
         valfn #(or (get % k) default "")
-        wrap (fn [f] (fn [st v] (f st v) (when on-change (on-change))))]
+        wrap (fn [f] (fn [st v] (f st v) (when on-change (on-change))))
+        input (case type
+                :textarea [dbfield :textarea {:id name :rows 4 :placeholder ph} cursor
+                           valfn (wrap #(swap! %1 assoc k %2))]
+                :select   [:select {:id name :value (or (get @cursor k) default "")
+                                    :on-change #(do (swap! cursor assoc k (.. % -target -value))
+                                                    (when on-change (on-change)))}
+                           (for [{:keys [value label]} options]
+                             [:option {:key value :value value} label])]
+                :checkbox [:input {:id name :type "checkbox"
+                                   :checked (true? (get @cursor k))
+                                   :on-change #(do (swap! cursor assoc k (.. % -target -checked))
+                                                   (when on-change (on-change)))}]
+                :csv      [dbfield :input {:id name :type "text" :placeholder ph} cursor
+                           #(clojure.string/join " " (get % k []))
+                           (wrap #(swap! %1 assoc k (clojure.string/split %2 #"[, ]+" -1)))]
+                ;; default: text input
+                          [dbfield :input {:id name :type "text" :placeholder ph} cursor
+                           valfn (wrap #(swap! %1 assoc k %2))])]
     [:<>
      [:label {:for name :title tooltip} name]
-     (case type
-       :textarea [dbfield :textarea {:id name :rows 4 :placeholder ph} cursor
-                  valfn (wrap #(swap! %1 assoc k %2))]
-       :select   [:select {:id name :value (or (get @cursor k) default "")
-                           :on-change #(do (swap! cursor assoc k (.. % -target -value))
-                                           (when on-change (on-change)))}
-                  (for [{:keys [value label]} options]
-                    [:option {:key value :value value} label])]
-       :csv      [dbfield :input {:id name :type "text" :placeholder ph} cursor
-                  #(clojure.string/join " " (get % k []))
-                  (wrap #(swap! %1 assoc k (clojure.string/split %2 #"[, ]+" -1)))]
-       ;; default: text input
-                 [dbfield :input {:id name :type "text" :placeholder ph} cursor
-                  valfn (wrap #(swap! %1 assoc k %2))])]))
+     (if extra-el
+       [:div.field-with-extra input extra-el]
+       input)]))
 
 (defn- list-editor
   "Render a list of maps: fieldset per item with add/remove, recurse per item."
-  [{:keys [tooltip children type] :or {type :label}} list-cursor on-change]
+  [{:keys [tooltip children type] :or {type :label}} list-cursor on-change wrap-leaf path]
   [:<>
    [type tooltip]
    (doall
@@ -95,9 +103,9 @@
           [:button.remove-btn {:on-click #(do (swap! list-cursor dissjoc idx)
                                               (when on-change (on-change)))
                                :title "Remove"} [x-circle] [x-circle-fill]]]
-         [recursive-editor children item-cursor on-change]])))
+         [recursive-editor children item-cursor on-change wrap-leaf (conj path idx)]])))
    [:button.add-btn {:on-click #(do (swap! list-cursor (fnil conj [])
-                                          (into {} (map (fn [{:keys [name default]}] [(keyword name) (or default "")]) children)))
+                                          (into {} (map (fn [{:keys [name default type]}] [(keyword name) (if (some? default) default (if (= type :checkbox) false ""))]) children)))
                                     (when on-change (on-change)))}
     [plus-circle] [plus-circle-fill] " Add"]])
 
@@ -105,16 +113,22 @@
   "Render editors for nested data. Each field is either a leaf or a list of maps.
    fields: [{:name :tooltip :type :children ...}]
    cursor: cursor to a map
-   on-change: optional callback fired after data changes (debounced for text fields)"
+   on-change: optional callback fired after data changes (debounced for text fields)
+   wrap-leaf: optional (fn [path editor]) to wrap each leaf with extra UI
+   path: keyword vector tracking current nesting depth"
   ([fields cursor] (recursive-editor fields cursor nil))
-  ([fields cursor on-change]
+  ([fields cursor on-change] (recursive-editor fields cursor on-change nil []))
+  ([fields cursor on-change wrap-leaf] (recursive-editor fields cursor on-change wrap-leaf []))
+  ([fields cursor on-change wrap-leaf path]
    [:<>
     (doall
      (for [{:keys [name children] :as field} fields]
-       [:<> {:key name}
-        (if children
-          [list-editor field (r/cursor cursor [(keyword name)]) on-change]
-          [leaf-editor field cursor on-change])]))]))
+       (let [new-path (conj path (keyword name))]
+         [:<> {:key name}
+          (if children
+            [list-editor field (r/cursor cursor [(keyword name)]) on-change wrap-leaf new-path]
+            [leaf-editor field cursor on-change
+             (when wrap-leaf (wrap-leaf new-path))])])))]))
 
 (defn sign [n] (if (> n 0) 1 -1))
 
@@ -500,6 +514,7 @@
 (def x-circle-fill (r/adapt-react-class icons/XCircleFill))
 (def plus-circle (r/adapt-react-class icons/PlusCircle))
 (def plus-circle-fill (r/adapt-react-class icons/PlusCircleFill))
+(def eye (r/adapt-react-class icons/Eye))
 (def history (r/adapt-react-class icons/ClockHistory))
 (def sun-icon (r/adapt-react-class icons/SunFill))
 (def moon-icon (r/adapt-react-class icons/MoonFill))
@@ -702,6 +717,16 @@
       (aset bytes i (.charCodeAt binary-string i)))
     (let [blob (js/Blob. #js[bytes] #js{:type content-type})]
       (.createObjectURL js/URL blob))))
+
+(defn generate-important-template
+  "Build a template string from props marked :important. Returns nil if none."
+  [props]
+  (let [important (filter :important props)]
+    (when (seq important)
+      (clojure.string/join "\n"
+        (cons "{self.name}"
+              (map #(str (:name %) ": {self.props." (:name %) "}")
+                   important))))))
 
 ;; Model ID utilities
 (defn model-key

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -617,7 +617,12 @@
         [dx dy] (apply max-key (fn [[x y]] (- x y)) rotated)
         desig-offset-x (+ dx 0.1)
         desig-offset-y (+ dy 0.25)]
-    (when-let [text (get v :template (get-in models [(:type v) ::template] "{self.name}"))]
+    (when-let [text (or (:template v)
+                        (when (seq (:model v))
+                          (cm/generate-important-template
+                            (:props (get @modeldb (cm/model-key (:model v))))))
+                        (get-in models [(:type v) ::template])
+                        "{self.name}")]
       [:text.identifier
        {:transform (-> (:transform v) transform
                        (.translate (* grid-size (/ size -2)) (* grid-size (/ size -2)))
@@ -1960,9 +1965,13 @@
   (let [props (r/cursor schematic [key :props])
         device-type (r/cursor schematic [key :type])
         model (r/cursor schematic [key :model])
-        name (r/cursor schematic [key :name])]
+        name (r/cursor schematic [key :name])
+        show-prop-insert (r/atom false)]
     (fn [key]
-      (let [model-def (get @modeldb (cm/model-key @model))]
+      (let [model-def (get @modeldb (cm/model-key @model))
+            effective-default (or (when model-def (cm/generate-important-template (:props model-def)))
+                                 (::template (get models @device-type))
+                                 "{self.name}")]
         [:<>
          [:h1 (or @name key)]
          [:div.properties
@@ -1974,13 +1983,14 @@
                    :default-value @name
                    :on-change (debounce #(do (reset! name (.. % -target -value)) (post-action!)))}]
           [:label {:for "model" :title "Device model"} "model"]
-          [:div.model-field
+          [:div.field-with-extra
            [:input {:id "model"
                     :type "text"
                     :read-only true
                     :value (or (:name model-def) (when (seq @model) @model) "Ideal")
                     :title (or @model "No model selected")}]
-           [:button {:on-click #(do
+           [:button {:title "Select model"
+                     :on-click #(do
                                   (reset! model-popup-filter "")
                                   (reset! model-popup-category [])
                                   (reset! cm/modal-content
@@ -1991,12 +2001,41 @@
             [cm/search]]]
           ; Get properties from built-in device and model
           (let [device-props (::props (get models @device-type) [])
-                model-props (:props model-def [])]
-            [cm/recursive-editor (concat device-props model-props) props post-action!])
-          [:label {:for "template" :title "Template to display"} "Text"]
-          [:textarea {:id "template"
-                      :default-value (get-in @schematic [key :template] (::template (get models @device-type)))
-                      :on-change (debounce #(do (swap! schematic assoc-in [key :template] (.. % -target -value)) (post-action!)))}]]]))))
+                model-props (:props model-def [])
+                all-props (concat device-props model-props)
+                prop-in-template? (fn [path]
+                                    (let [path-str (clojure.string/join "." (map clojure.core/name path))
+                                          needle (str "self.props." path-str)
+                                          tmpl (or (:template (get @schematic key)) effective-default)]
+                                      (clojure.string/includes? tmpl needle)))
+                insert-prop (fn [path]
+                              (when-not (prop-in-template? path)
+                                (let [path-str (clojure.string/join "." (map clojure.core/name path))
+                                      label (clojure.core/name (last path))]
+                                  (swap! schematic update-in [key :template]
+                                    (fn [current]
+                                      (let [base (or current effective-default)]
+                                        (str base "\n" label ": {self.props." path-str "}"))))
+                                  (post-action!))))]
+            [cm/recursive-editor all-props props post-action!
+             (when @show-prop-insert
+               (fn [path]
+                 (let [already? (prop-in-template? path)]
+                   [:button.prop-eye
+                    {:on-click #(insert-prop path)
+                     :title (if already? "Already in template" "Add to template")
+                     :disabled already?}
+                    [cm/eye]])))])
+          [:div.template-header
+           [:label {:for "template" :title "Template to display"} "Text"]
+           [:button.add-btn
+            {:on-click #(swap! show-prop-insert not)
+             :class (when @show-prop-insert "active")}
+            [cm/plus-circle] [cm/plus-circle-fill] " Add"]]
+          [cm/dbfield :textarea {:id "template" :rows 4}
+           (r/cursor schematic [key])
+           #(or (:template %) effective-default)
+           (fn [st v] (swap! st assoc :template v) (post-action!))]]]))))
 
 (defn copy []
   (let [sel @selected

--- a/src/main/nyancad/mosaic/libman.cljc
+++ b/src/main/nyancad/mosaic/libman.cljc
@@ -91,7 +91,8 @@
    [{:name "props" :tooltip "Parameters" :type :h4
      :children [{:name "name" :tooltip "Parameter name"}
                 {:name "tooltip" :tooltip "Description"}
-                {:name "default" :tooltip "Default value"}]}]
+                {:name "default" :tooltip "Default value"}
+                {:name "important" :tooltip "Show on schematic" :type :checkbox}]}]
    cell])
 
 (defn model-properties


### PR DESCRIPTION
## Summary
Closes #137

- Model authors can mark parameters as "important" via checkbox in library manager — these auto-generate a default template showing key properties on the schematic
- Per-instance "+ Add" toggle reveals eye buttons inline next to each property to append it to the template
- Duplicate detection disables the eye button when a property is already in the template
- Template textarea is now controlled via dbfield for consistency
- Unified `.field-with-extra` styling shared by model selector and property eye buttons
- Label columns capped at 10ch to prevent long names squishing inputs
- General `button:disabled` styling, active toggle state with accent color

## Test plan
- [x] In library manager: edit a model, verify "important" checkbox appears on each parameter
- [x] Check "important" on a prop → device on schematic shows the property without instance template
- [x] Select a device → template textarea shows effective template
- [x] Click "+ Add" → eye icons appear inline next to each property input
- [x] Click eye → property appended to template, visible on schematic and in textarea
- [x] Eye button disabled for properties already in template
- [ ] Nested/tuple props: eye generates correct `self.props.parent.child` path
- [x] Model selector search button still works and matches eye button styling
- [x] Manual template editing still works
- [x] Dark theme: active toggle and disabled states render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)