### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/python/nyancad"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/python/nyancad-server"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
Adds Dependabot to keep dependencies up to date with weekly checks for:
- GitHub Actions (e.g., `actions/checkout@v2` → latest)
- npm packages
- pip dependencies for both `nyancad` and `nyancad-server`

## Test plan
- [ ] Dependabot creates PRs for outdated dependencies after merge