### PR TITLE
Separate CouchDB upload from build for dependabot CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
   - package-ecosystem: "pip"
     directory: "/python/nyancad"
     schedule:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,13 +46,17 @@ jobs:
           gem install jekyll jekyll-theme-slate
 
       - name: Build JS (required for Python packages)
+        run: |
+          npm install
+          npx shadow-cljs clj-run nyancad.mosaic.build/release
+
+      - name: Upload CouchDB design document
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
         env:
           COUCHDB_URL: https://api.nyancad.com
           COUCHDB_ADMIN_USER: ${{ secrets.COUCHDB_ADMIN_USER }}
           COUCHDB_ADMIN_PASS: ${{ secrets.COUCHDB_ADMIN_PASS }}
-        run: |
-          npm install
-          npx shadow-cljs clj-run nyancad.mosaic.build/release
+        run: bash src/bash/couchdb-upload-design-doc.sh
 
       - name: Build VSCode extension
         run: |

--- a/src/bash/couchdb-build-design-doc.sh
+++ b/src/bash/couchdb-build-design-doc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2024 Pepijn de Vos
+# SPDX-License-Identifier: MPL-2.0
+
+set -e
+
+DIR="$(dirname "$0")"
+DESIGN_DOC="$DIR/../../public/design-doc.json"
+
+# Build design document by injecting compiled view.js into the template
+jq '.views.lib.cljs = $js' --rawfile js "$DIR/../../public/js/view.js" "$DIR/view.json" > "$DESIGN_DOC"

--- a/src/bash/couchdb-upload-design-doc.sh
+++ b/src/bash/couchdb-upload-design-doc.sh
@@ -15,9 +15,6 @@ COUCHDB_ADMIN_PASS="${COUCHDB_ADMIN_PASS:-}"
 # Remove trailing slash from URL
 COUCHDB_URL="${COUCHDB_URL%/}"
 
-# Build design document
-jq '.views.lib.cljs = $js' --rawfile js "$DIR/../../public/js/view.js" "$DIR/view.json" > "$DESIGN_DOC"
-
 # Try to fetch existing design document to get _rev
 EXISTING_DOC=$(curl -s -u "$COUCHDB_ADMIN_USER:$COUCHDB_ADMIN_PASS" \
   "$COUCHDB_URL/models/_design/models" || echo '{}')

--- a/src/main/nyancad/mosaic/build.clj
+++ b/src/main/nyancad/mosaic/build.clj
@@ -19,7 +19,7 @@
   (sh! "bash" "src/bash/marimo-export.sh")
   (sh! "bash" "src/bash/jekyll-build.sh")
   (shadow/release :couchdb)
-  (sh! "bash" "src/bash/couchdb-export.sh"))
+  (sh! "bash" "src/bash/couchdb-build-design-doc.sh"))
 
 (defn release-vscode
   "Build VSCode extension (webview frontend + extension host).


### PR DESCRIPTION
## Summary
- Split `couchdb-export.sh` into `couchdb-build-design-doc.sh` (JSON generation) and `couchdb-upload-design-doc.sh` (CouchDB upload)
- Build/release now only generates the design doc JSON without uploading
- CouchDB upload runs as a conditional CI step only on `main` pushes and tagged releases

## Why
All dependabot PRs fail CI because GitHub doesn't expose repository secrets to dependabot-triggered workflows. The CouchDB upload (which needs admin credentials) was embedded in the build step, so the entire build failed with 401 Unauthorized.

## Test plan
- [ ] Verify this PR's own CI passes (no secrets needed for build)
- [ ] Verify CouchDB upload still works on next merge to main / tagged release
- [ ] Re-run one of the dependabot PRs to confirm they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)