### PR TITLE
Update Reagent 2.0.1 + React 19 + shadow-cljs 3.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@vscode/vsce": "^3.2.0",
-    "shadow-cljs": "^3.1.4"
+    "shadow-cljs": "^3.3.6"
   },
   "dependencies": {
     "bootstrap-icons": "^1.11.2",
@@ -12,8 +12,8 @@
     "jsonc-parser": "^3.3.1",
     "pouchdb": "^9.0.0",
     "pouchdb-find": "^9.0.0",
-    "react": "^18.3.1",
+    "react": "^19.2.0",
     "react-bootstrap-icons": "^1.10.3",
-    "react-dom": "^18.3.1"
+    "react-dom": "^19.2.0"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -9,7 +9,7 @@
   "src/test"]
 
  :dependencies
- [[reagent "1.3.0"]]
+ [[reagent "2.0.1"]]
 
  :dev-http {8080 {:root "public" :host "0.0.0.0"}}
  :builds

--- a/src/main/nyancad/mosaic/auth.cljs
+++ b/src/main/nyancad/mosaic/auth.cljs
@@ -4,7 +4,7 @@
 
 (ns nyancad.mosaic.auth
   (:require [reagent.core :as r]
-            [reagent.dom :as rd]
+            [reagent.dom.client :as rdc]
             [cljs.core.async :refer [go]]
             [cljs.core.async.interop :refer-macros [<p!]]
             [nyancad.mosaic.common :as cm]))
@@ -244,9 +244,10 @@
           nil)))))
 
 ;; Initialization
+(defonce root (rdc/create-root (.getElementById js/document "mosaic_auth")))
+
 (defn ^:dev/after-load render []
-  (rd/render [auth-page]
-             (.getElementById js/document "mosaic_auth")))
+  (rdc/render root [auth-page]))
 
 (defn ^:export init []
   (set! js/window.name "auth")

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -4,7 +4,7 @@
 
 (ns nyancad.mosaic.editor
   (:require [reagent.core :as r]
-            [reagent.dom :as rd]
+            [reagent.dom.client :as rdc]
             [shadow.resource :as rc]
             #?@(:vscode [[nyancad.mosaic.editor.platform-vscode
                            :refer [group schematic modeldb snapshots simulations local
@@ -2562,11 +2562,12 @@
 (def immediate-shortcuts
   {#{(keyword " ")} (fn [] (swap! ui #(assoc % ::tool ::pan ::prev-tool (::tool %))))})
 
+(defonce root (rdc/create-root (.querySelector js/document ".mosaic-app.mosaic-editor")))
+
 (defn ^:dev/after-load ^:export  render []
   (set! js/document.onkeyup (partial cm/keyboard-shortcuts shortcuts))
   (set! js/document.onkeydown (partial cm/keyboard-shortcuts immediate-shortcuts))
-  (rd/render [schematic-ui]
-             (.querySelector js/document ".mosaic-app.mosaic-editor")))
+  (rdc/render root [schematic-ui]))
 
 (defn ^:export init []
   (init-extra!)

--- a/src/main/nyancad/mosaic/libman.cljc
+++ b/src/main/nyancad/mosaic/libman.cljc
@@ -5,7 +5,7 @@
 (ns nyancad.mosaic.libman
   (:require clojure.string
             [reagent.core :as r]
-            [reagent.dom :as rd]
+            [reagent.dom.client :as rdc]
             #?@(:vscode [[nyancad.mosaic.libman.platform-vscode
                            :refer [modeldb syncactive
                                    preview-url get-preview search-remote-models
@@ -239,9 +239,10 @@
 
 (def shortcuts {})
 
+(defonce root (rdc/create-root (.querySelector js/document ".mosaic-app.mosaic-libman")))
+
 (defn ^:dev/after-load render []
-  (rd/render [library-manager]
-             (.querySelector js/document ".mosaic-app.mosaic-libman")))
+  (rdc/render root [library-manager]))
 
 (defn ^:export init []
   (set! js/window.name "libman")


### PR DESCRIPTION
## Summary
- Update Reagent 1.3.0 → 2.0.1, React 18 → 19, shadow-cljs 3.1.4 → 3.3.6
- Migrate `reagent.dom/render` → `reagent.dom.client/create-root` + `render` in 3 files (auth, editor, libman)
- No other breaking changes apply: no form-3 components, no `force-update`, `r/unsafe-html` already in use

## Test plan
- [x] `npx shadow-cljs compile frontend` — 0 warnings
- [x] `npx shadow-cljs compile vscode-webview` — 0 warnings
- [x] Manual test of editor in browser
- [x] Verify hot reload with `shadow-cljs watch`
- [x] Test libman and auth pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)