### PR TITLE
Add automatic VS Code extension publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,6 +166,31 @@ jobs:
             rm /tmp/nyancad-*.whl /tmp/nyancad_server-*.whl
           "
 
+  publish-vscode-extension:
+    name: Publish VS Code Extension 📦
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download VSCode extension
+        uses: actions/download-artifact@v8
+        with:
+          name: vscode-extension
+          path: artifacts/
+
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          extensionFile: artifacts/*.vsix
+
+      - name: Publish to VS Code Marketplace
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.VSCE_PAT }}
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: artifacts/*.vsix
+
   create-github-release:
     name: Create GitHub Release
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
- Adds a `publish-vscode-extension` job to CI that publishes to both VS Code Marketplace and Open VSX Registry on tag pushes
- Uses [HaaLeo/publish-vscode-extension@v2](https://github.com/HaaLeo/publish-vscode-extension) with pre-built `.vsix` artifact
- Requires `VSCE_PAT` and `OPEN_VSX_TOKEN` secrets (already configured)

## Test plan
- [ ] Merge and push a tag to trigger the publish job
- [ ] Verify extension appears on https://marketplace.visualstudio.com/items?itemName=nyancad.mosaic-schematic
- [ ] Verify extension appears on https://open-vsx.org/extension/nyancad/mosaic-schematic

🤖 Generated with [Claude Code](https://claude.com/claude-code)