### PR TITLE
Dark theme: VS Code detection and marimo propagation

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1104,7 +1104,11 @@ rect.select {
     cursor: url(icons/eraser.svg) 6 14, crosshair;
 }
 
-/* Light cursors for dark mode — auto (OS) and forced */
+/* VS Code theme: propagate to color-scheme so light-dark() responds */
+.vscode-dark { color-scheme: dark; }
+.vscode-light { color-scheme: light; }
+
+/* Light cursors for dark mode — auto (OS), manual toggle, and VS Code */
 @media (prefers-color-scheme: dark) {
     .mosaic-canvas.pan { cursor: url(icons/arrows-move-light.svg) 6 0, grab; }
     .mosaic-canvas.wire { cursor: url(icons/pencil-light.svg) 0 16, crosshair; }
@@ -1112,11 +1116,16 @@ rect.select {
     .mosaic-canvas.eraser .wire:hover,
     .mosaic-canvas.eraser .device { cursor: url(icons/eraser-light.svg) 6 14, crosshair; }
 }
-.dark-cursors .mosaic-canvas.pan { cursor: url(icons/arrows-move-light.svg) 6 0, grab; }
-.dark-cursors .mosaic-canvas.wire { cursor: url(icons/pencil-light.svg) 0 16, crosshair; }
-.dark-cursors .mosaic-canvas.probe { cursor: url(icons/search-light.svg) 5 5, crosshair; }
+.dark-cursors .mosaic-canvas.pan,
+.vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.pan { cursor: url(icons/arrows-move-light.svg) 6 0, grab; }
+.dark-cursors .mosaic-canvas.wire,
+.vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.wire { cursor: url(icons/pencil-light.svg) 0 16, crosshair; }
+.dark-cursors .mosaic-canvas.probe,
+.vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.probe { cursor: url(icons/search-light.svg) 5 5, crosshair; }
 .dark-cursors .mosaic-canvas.eraser .wire:hover,
-.dark-cursors .mosaic-canvas.eraser .device { cursor: url(icons/eraser-light.svg) 6 14, crosshair; }
+.dark-cursors .mosaic-canvas.eraser .device,
+.vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.eraser .wire:hover,
+.vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.eraser .device { cursor: url(icons/eraser-light.svg) 6 14, crosshair; }
 
 
 line.grid {

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -2071,10 +2071,11 @@
 (defn- dark-mode?
   ([] (dark-mode? @theme))
   ([t]
-   (case t
-     "dark" true
-     "light" false
-     (.-matches (js/window.matchMedia "(prefers-color-scheme: dark)")))))
+   (cond
+     (= t "dark") true
+     (= t "light") false
+     (.. js/document -body -classList (contains "vscode-dark")) true
+     :else (.-matches (js/window.matchMedia "(prefers-color-scheme: dark)")))))
 
 (defn toggle-theme! []
   (let [now (.now js/Date)
@@ -2468,18 +2469,19 @@
                        (map #(vector % (get schem %)) sel))]])))
 
 (defn- set-color-scheme!
-  "Set color-scheme on :root so light-dark() CSS function responds correctly."
+  "Set color-scheme on body so light-dark() CSS function responds correctly.
+   Targets body so inline style overrides VS Code's .vscode-dark class."
   [scheme]
-  (.. js/document -documentElement -style (setProperty "color-scheme" scheme)))
+  (.. js/document -body -style (setProperty "color-scheme" scheme)))
 
 (defn- theme-attrs
   "CSS attributes for the current theme. Returns {:class ...}"
   []
   (case @theme
     "eyesore" (do (set-color-scheme! "light") {:class "eyesore dark-cursors"})
-    "light"   (do (set-color-scheme! "light") {})
+    "light"   (do (set-color-scheme! "light") {:class "light-cursors"})
     "dark"    (do (set-color-scheme! "dark") {:class "dark-cursors"})
-    (do (set-color-scheme! "light dark") {})))
+    {}))
 
 (defn schematic-ui []
   [:div.mosaic-container (theme-attrs)

--- a/src/marimo/notebook.py
+++ b/src/marimo/notebook.py
@@ -1,3 +1,8 @@
+# /// script
+# [tool.marimo.display]
+# theme = "system"
+# ///
+
 import marimo
 
 __generated_with = "0.19.6"

--- a/src/marimo/notebook_file.py
+++ b/src/marimo/notebook_file.py
@@ -1,3 +1,8 @@
+# /// script
+# [tool.marimo.display]
+# theme = "system"
+# ///
+
 import marimo
 
 __generated_with = "0.23.1"


### PR DESCRIPTION
## Summary
- Adds CSS rules to propagate VS Code's `.vscode-dark`/`.vscode-light` body classes to `color-scheme`, so all `light-dark()` CSS variables respond automatically
- Moves `set-color-scheme!` from `:root` to body so manual theme toggle overrides VS Code's class
- Adds `light-cursors` class and `.vscode-dark .mosaic-container:not(.light-cursors)` cursor selectors to handle all dark/light combinations correctly
- TODO: propagate theme to embedded marimo notebooks

## Test plan
- [ ] Open schematic in VS Code with dark theme — verify colors and cursors are dark
- [ ] Toggle Mosaic theme to light in VS Code dark — verify colors and cursors switch to light
- [ ] Open schematic in VS Code with light theme — verify default light appearance
- [ ] Open schematic in browser — verify OS auto-detection still works
- [ ] Toggle theme in browser — verify manual toggle still works
- [ ] Verify eyesore easter egg still works (5 rapid clicks)
- [ ] Verify marimo notebook follows theme (TODO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)