### PR TITLE
Fix libman theming on OS/VS Code theme mismatch (#173)

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1104,9 +1104,20 @@ rect.select {
     cursor: url(icons/eraser.svg) 6 14, crosshair;
 }
 
-/* VS Code theme: propagate to color-scheme so light-dark() responds */
-.vscode-dark { color-scheme: dark; }
-.vscode-light { color-scheme: light; }
+/* Propagate effective color-scheme to :root so <html>'s UA-default
+   background matches the theme. VS Code applies .vscode-dark/.vscode-light
+   to <body> only, which leaves <html>'s default bg tied to the OS
+   prefers-color-scheme — causing light panels on a dark backdrop when
+   the OS and VS Code themes disagree (#173). Later rules win on equal
+   specificity; manual container-class rules also have higher specificity
+   than the VS Code body-class rules, so manual toggle always wins. */
+:root:has(body.vscode-dark) { color-scheme: dark; }
+:root:has(body.vscode-light) { color-scheme: light; }
+:root:has(.mosaic-container.dark-cursors) { color-scheme: dark; }
+:root:has(.mosaic-container.light-cursors) { color-scheme: light; }
+/* Eyesore easter-egg: dark canvas with light chrome — overrides
+   .dark-cursors above. */
+:root:has(.mosaic-container.eyesore) { color-scheme: light; }
 
 /* Light cursors for dark mode — auto (OS), manual toggle, and VS Code */
 @media (prefers-color-scheme: dark) {

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -2224,7 +2224,9 @@
    (cond
      (= t "dark") true
      (= t "light") false
+     (= t "eyesore") false
      (.. js/document -body -classList (contains "vscode-dark")) true
+     (.. js/document -body -classList (contains "vscode-light")) false
      :else (.-matches (js/window.matchMedia "(prefers-color-scheme: dark)")))))
 
 (defn toggle-theme! []
@@ -2617,19 +2619,14 @@
                      (let [schem @schematic]
                        (map #(vector % (get schem %)) sel))]])))
 
-(defn- set-color-scheme!
-  "Set color-scheme on body so light-dark() CSS function responds correctly.
-   Targets body so inline style overrides VS Code's .vscode-dark class."
-  [scheme]
-  (.. js/document -body -style (setProperty "color-scheme" scheme)))
-
 (defn- theme-attrs
-  "CSS attributes for the current theme. Returns {:class ...}"
+  "CSS classes for the current manual theme. :root:has() rules in
+   style.css pick up these container classes and set color-scheme."
   []
   (case @theme
-    "eyesore" (do (set-color-scheme! "light") {:class "eyesore dark-cursors"})
-    "light"   (do (set-color-scheme! "light") {:class "light-cursors"})
-    "dark"    (do (set-color-scheme! "dark") {:class "dark-cursors"})
+    "eyesore" {:class "eyesore dark-cursors"}
+    "light"   {:class "light-cursors"}
+    "dark"    {:class "dark-cursors"}
     {}))
 
 (defn schematic-ui []


### PR DESCRIPTION
## Summary
- Propagate VS Code's theme to `:root` via `:root:has(body.vscode-*)` so `<html>`'s UA-default background matches the theme; fixes the "light panels on dark backdrop" in libman when OS and VS Code themes disagree (#173).
- Drop the `set-color-scheme!` JS workaround — the inline-style override only existed because VS Code's class is on `<body>`, and `:root:has()` lets CSS specificity handle the manual-toggle override instead.
- Make `dark-mode?` check `.vscode-light` and eyesore so the sun/moon button state matches the new CSS cascade.

## Test plan
- [ ] OS dark + VS Code dark → fully dark (libman + editor).
- [ ] OS dark + VS Code light → fully **light** (the #173 bug case).
- [ ] OS light + VS Code dark → fully dark.
- [ ] OS light + VS Code light → fully light.
- [ ] Editor sun/moon toggle overrides the VS Code theme in all four combinations; button icon reflects the current effective theme.
- [ ] Eyesore (5 rapid toggle clicks in the editor): chrome stays light, canvas goes black/neon, cursor icons are the light-on-dark set.
- [ ] Standalone web libman/editor (no `.vscode-*` class) still follows OS `prefers-color-scheme`.
- [ ] DevTools check in the bug case: `<html>` computed `color-scheme` is `light`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)