### PR TITLE
fix(ci): resolve CI and release workflow warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,9 +181,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [test-python-unit, test-cljs-unit, build]
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
     steps:
       - name: Download nyancad distributions
         uses: actions/download-artifact@v8
@@ -192,15 +189,15 @@ jobs:
           path: dist/
       - name: Publish nyancad distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: false
 
   publish-nyancad-server-to-pypi:
     name: Publish nyancad-server 🐍 distribution 📦 to PyPI
     if: startsWith(github.ref, 'refs/tags/')
     needs: [test-python-unit, test-cljs-unit, build]
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
     steps:
       - name: Download nyancad-server distributions
         uses: actions/download-artifact@v8
@@ -209,6 +206,9 @@ jobs:
           path: dist/
       - name: Publish nyancad-server distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: false
 
   deploy:
     name: Deploy to server 🚀

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,6 +181,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [test-python-unit, test-cljs-unit, build]
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
       - name: Download nyancad distributions
         uses: actions/download-artifact@v8
@@ -189,14 +192,15 @@ jobs:
           path: dist/
       - name: Publish nyancad distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   publish-nyancad-server-to-pypi:
     name: Publish nyancad-server 🐍 distribution 📦 to PyPI
     if: startsWith(github.ref, 'refs/tags/')
     needs: [test-python-unit, test-cljs-unit, build]
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
       - name: Download nyancad-server distributions
         uses: actions/download-artifact@v8
@@ -205,8 +209,6 @@ jobs:
           path: dist/
       - name: Publish nyancad-server distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   deploy:
     name: Deploy to server 🚀
@@ -250,6 +252,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [test-python-unit, test-cljs-unit, build]
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Download VSCode extension
         uses: actions/download-artifact@v8

--- a/python/nyancad-server/pyproject.toml
+++ b/python/nyancad-server/pyproject.toml
@@ -8,14 +8,13 @@ version = "0.17.0"
 description = "NyanCAD server package with marimo integration"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MPL-2.0"}
+license = "MPL-2.0"
 authors = [
     {name = "Pepijn de Vos", email = "me@pepijndevos.nl"},
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/python/nyancad/pyproject.toml
+++ b/python/nyancad/pyproject.toml
@@ -8,14 +8,13 @@ version = "0.14.0"
 description = "NyanCAD Python library for schematic editor with anywidget integration"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MPL-2.0"}
+license = "MPL-2.0"
 authors = [
     {name = "Pepijn de Vos", email = "me@pepijndevos.nl"},
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -26,7 +25,7 @@ classifiers = [
 dependencies = [
     "anywidget>=0.9.0",
     "traitlets",
-    "InSpice[vacask]",
+    "InSpice",
     "holoviews",
 ]
 

--- a/src/main/nyancad/hipflask.cljs
+++ b/src/main/nyancad/hipflask.cljs
@@ -77,7 +77,7 @@
      (let [result (find db #js{:selector (clj->js selector)
                                :limit limit})
            response (<p! result)
-           docs (json->clj (.-docs response))]
+           docs (json->clj (unchecked-get response "docs"))]
        (into {} (map (juxt :_id identity)) docs)))))
 
 (defn- init-cache [db group cache]

--- a/src/test/nyancad/hipflask_test.cljs
+++ b/src/test/nyancad/hipflask_test.cljs
@@ -95,10 +95,10 @@
           (is (not (contains? @pa "grp:x")))
           ;; verify the doc is gone from the DB too (alldocs without
           ;; {keys: [...]} skips tombstones).
-          (let [^js res (<p! (hf/alldocs db #js {:include_docs true
-                                                 :startkey "grp:"
-                                                 :endkey "grp:\ufff0"}))]
-            (is (zero? (.-total_rows res))
+          (let [res (<p! (hf/alldocs db #js {:include_docs true
+                                            :startkey "grp:"
+                                            :endkey "grp:\ufff0"}))]
+            (is (zero? (unchecked-get res "total_rows"))
                 "deleted doc should not appear in alldocs result")))
         (done)))))
 
@@ -202,7 +202,7 @@
         (let [db (mem-db)
               pa (hf/pouch-atom db "grp")]
           (<! (hf/done? pa))
-          (set! (.-validator ^js pa) (constantly true))
+          (unchecked-set pa "validator" (constantly true))
           (<! (swap! pa assoc "grp:x" {:n 7}))
           (is (= 7 (get-in @pa ["grp:x" :n]))))
         (done)))))


### PR DESCRIPTION
- Resolve CLJS infer warnings (unchecked-get/set in go blocks)
- Update setuptools license format to PEP 639 standard
- Remove non-existent InSpice[vacask] extra
- Add Node.js 24 env var for VS Code publisher action
- Keep password-based PyPI auth and disable attestations