### PR TITLE
Fix CI warnings from PyPI publisher, CLJS compiler, and license metadata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,6 +191,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: false
 
   publish-nyancad-server-to-pypi:
     name: Publish nyancad-server 🐍 distribution 📦 to PyPI
@@ -207,6 +208,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: false
 
   deploy:
     name: Deploy to server 🚀
@@ -251,6 +253,11 @@ jobs:
     needs: [test-python-unit, test-cljs-unit, build]
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
       - name: Download VSCode extension
         uses: actions/download-artifact@v8
         with:
@@ -262,17 +269,10 @@ jobs:
         run: echo "path=$(ls artifacts/*.vsix)" >> "$GITHUB_OUTPUT"
 
       - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v2
-        with:
-          pat: ${{ secrets.OPEN_VSX_TOKEN }}
-          extensionFile: ${{ steps.vsix.outputs.path }}
+        run: npx ovsx publish "${{ steps.vsix.outputs.path }}" -p "${{ secrets.OPEN_VSX_TOKEN }}"
 
       - name: Publish to VS Code Marketplace
-        uses: HaaLeo/publish-vscode-extension@v2
-        with:
-          pat: ${{ secrets.VSCE_PAT }}
-          registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ steps.vsix.outputs.path }}
+        run: npx @vscode/vsce publish --packagePath "${{ steps.vsix.outputs.path }}" -p "${{ secrets.VSCE_PAT }}"
 
   create-github-release:
     name: Create GitHub Release

--- a/python/nyancad-server/pyproject.toml
+++ b/python/nyancad-server/pyproject.toml
@@ -8,14 +8,13 @@ version = "0.17.0"
 description = "NyanCAD server package with marimo integration"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MPL-2.0"}
+license = "MPL-2.0"
 authors = [
     {name = "Pepijn de Vos", email = "me@pepijndevos.nl"},
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/python/nyancad/pyproject.toml
+++ b/python/nyancad/pyproject.toml
@@ -8,14 +8,13 @@ version = "0.14.0"
 description = "NyanCAD Python library for schematic editor with anywidget integration"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MPL-2.0"}
+license = "MPL-2.0"
 authors = [
     {name = "Pepijn de Vos", email = "me@pepijndevos.nl"},
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",

--- a/src/main/nyancad/hipflask.cljs
+++ b/src/main/nyancad/hipflask.cljs
@@ -70,14 +70,16 @@
                                    :limit limit})]
      (go (docs-into {} (<p! result) :value)))))
 
+(defn- find-docs [^js response]
+  (json->clj (.-docs response)))
+
 (defn get-mango-group
   ([db selector] (get-mango-group db selector nil))
   ([db selector limit]
    (go
      (let [result (find db #js{:selector (clj->js selector)
                                :limit limit})
-           response (<p! result)
-           docs (json->clj (.-docs response))]
+           docs (find-docs (<p! result))]
        (into {} (map (juxt :_id identity)) docs)))))
 
 (defn- init-cache [db group cache]

--- a/src/test/nyancad/hipflask_test.cljs
+++ b/src/test/nyancad/hipflask_test.cljs
@@ -23,6 +23,10 @@
   []
   (PouchDB. (str "testdb-" (random-uuid)) #js {:adapter "memory"}))
 
+(defn- total-rows [^js res] (.-total_rows res))
+
+(defn- set-patom-validator! [^js pa f] (set! (.-validator pa) f))
+
 ;; ---------------------------------------------------------------------------
 ;; Low-level PouchDB helpers
 ;; ---------------------------------------------------------------------------
@@ -95,10 +99,10 @@
           (is (not (contains? @pa "grp:x")))
           ;; verify the doc is gone from the DB too (alldocs without
           ;; {keys: [...]} skips tombstones).
-          (let [^js res (<p! (hf/alldocs db #js {:include_docs true
-                                                 :startkey "grp:"
-                                                 :endkey "grp:\ufff0"}))]
-            (is (zero? (.-total_rows res))
+          (let [res (<p! (hf/alldocs db #js {:include_docs true
+                                            :startkey "grp:"
+                                            :endkey "grp:\ufff0"}))]
+            (is (zero? (total-rows res))
                 "deleted doc should not appear in alldocs result")))
         (done)))))
 
@@ -202,7 +206,7 @@
         (let [db (mem-db)
               pa (hf/pouch-atom db "grp")]
           (<! (hf/done? pa))
-          (set! (.-validator ^js pa) (constantly true))
+          (set-patom-validator! pa (constantly true))
           (<! (swap! pa assoc "grp:x" {:n 7}))
           (is (= 7 (get-in @pa ["grp:x" :n]))))
         (done)))))


### PR DESCRIPTION
Suppress CI/release workflow warnings across multiple tools:

- **PyPI publisher:** Added `attestations: false` to suppress warning with password-based auth
- **VS Code publisher:** Replaced unmaintained HaaLeo/publish-vscode-extension@v2 (Node.js 20) with direct CLI calls (`npx ovsx` / `npx @vscode/vsce`) via setup-node with Node 22
- **License metadata:** Updated pyproject.toml to PEP 639 string format, removed deprecated license classifier
- **CLJS compiler:** Extracted JS interop helpers out of core.async go blocks so `^js` type hints survive state machine transform (fixes 3 `:infer-warning` warnings)