### PR TITLE
Index tags for model search + verify migrated :lib model netlisting

### DIFF
--- a/python/nyancad/nyancad/netlist.py
+++ b/python/nyancad/nyancad/netlist.py
@@ -696,11 +696,15 @@ class NyanCircuit(NyanCADMixin, Circuit):
                     if entry:
                         # Handle library includes
                         if entry.get("library"):
+                            library = entry["library"]
+                            resolved = self._resolve_url(library)
+                            if resolved is not None:
+                                library = str(resolved)
                             section = _select_corner(entry.get("sections"), corners)
                             if section:
-                                self.lib(entry["library"], section)
+                                self.lib(library, section)
                             else:
-                                self.include(entry["library"])
+                                self.include(library)
                         # Handle inline SPICE code
                         code = entry.get("code", "").strip()
                         if code:
@@ -736,9 +740,6 @@ class NyanCircuit(NyanCADMixin, Circuit):
             # Parse SPICE code
             spice_source = SpiceSource(spice_code, title_line=False)
 
-            # Resolve URL includes in the SpiceSource before building
-            self.resolve_url_includes(spice_source)
-
             builder = Builder()
             parsed_circuit = builder.translate(spice_source)
             # Copy all content to self (models, subcircuits, elements)
@@ -760,52 +761,22 @@ class NyanCircuit(NyanCADMixin, Circuit):
             # Append to raw_spice
             self.raw_spice += "\n" + spice_code.strip() + "\n"
 
-    def _resolve_url_path(self, path_obj):
-        """Helper to resolve a single URL path to a local file path."""
+    def _resolve_url(self, path_str):
+        """Resolve an http(s) library/include URL to a local cache path and register
+        the archive for download. Returns the resolved Path, or None when path_str is
+        not an http(s) URL (caller keeps the original path)."""
+        parsed = urlparse(path_str)
+        if parsed.scheme not in ("http", "https"):
+            return None
+        archive_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+        entrypoint = parsed.fragment
         cache_dir = Path(tempfile.gettempdir()) / "nyancad_archive_cache"
         cache_dir.mkdir(exist_ok=True)
-
-        # Get the raw path from the AST
-        ast = path_obj._ast
-        path_str = str(next(iter(ast))).strip("\"'")
-
-        parsed = urlparse(path_str)
-
-        if parsed.scheme in ("http", "https"):
-            archive_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
-            entrypoint = parsed.fragment
-
-            # Generate cache key from URL
-            url_hash = hashlib.md5(archive_url.encode()).hexdigest()[:8]  # noqa: S324
-            filename = Path(parsed.path).name
-            cached_file = cache_dir / f"{url_hash}_{filename}"
-
-            # Schedule download if not cached
-            if not cached_file.exists():
-                self._pending_downloads.append((archive_url, cached_file, entrypoint))
-
-            # Compute the expected resolved path (will exist after download/extract)
-            if entrypoint:
-                base_name = cached_file.stem
-                extract_dir = cache_dir / base_name
-                resolved_path = extract_dir / entrypoint
-            else:
-                # Bare SPICE file - use directly
-                resolved_path = cached_file
-
-            # Replace the _path in the object
-            path_obj._path = resolved_path
-
-    def resolve_url_includes(self, spice_source):
-        """Resolve HTTP includes (archives or bare files) to local paths."""
-        # Process includes
-        for include in spice_source._includes:
-            self._resolve_url_path(include)
-
-        # Also process libs if they exist
-        if hasattr(spice_source, "_libs"):
-            for lib in spice_source._libs:
-                self._resolve_url_path(lib)
+        url_hash = hashlib.md5(archive_url.encode()).hexdigest()[:8]  # noqa: S324
+        cached_file = cache_dir / f"{url_hash}_{Path(parsed.path).name}"
+        if not cached_file.exists():
+            self._pending_downloads.append((archive_url, cached_file, entrypoint))
+        return (cache_dir / cached_file.stem / entrypoint) if entrypoint else cached_file
 
 
 class NyanSubCircuit(NyanCADMixin, SubCircuit):

--- a/python/nyancad/nyancad/netlist.py
+++ b/python/nyancad/nyancad/netlist.py
@@ -534,9 +534,14 @@ class NyanCADMixin:
 
         # Helper to get port by name. The editor annotates every port with
         # a net — disconnected pins get their own generated netN — so the
-        # lookup is total and a plain dict access is correct.
+        # lookup is total. Built-in device symbols label pins with uppercase
+        # chars (D/G/S/B), while a model's port-order may use any case (sky130
+        # subckts migrated by SpiceArmyKnife.jl use lowercase d/g/s/b). SPICE is
+        # case-insensitive, so resolve port names case-insensitively.
+        ports_ci = {k.lower(): v for k, v in ports.items()}
+
         def p(port_name):
-            return ports[port_name]
+            return ports_ci[port_name.lower()]
 
         # Map SPICE element type letters to InSpice methods
         _spice_type_map = {

--- a/python/nyancad/nyancad/netlist.py
+++ b/python/nyancad/nyancad/netlist.py
@@ -532,6 +532,12 @@ class NyanCADMixin:
                         props.setdefault(mp["name"], mp["default"])
                 props.setdefault("model", model_name)
 
+        # Drop params with no value: an empty override is meaningless to SPICE
+        # and would emit invalid `param=` lines, clobbering the model/subckt's
+        # own default. Only ""/None are dropped — 0, False and other native-JSON
+        # values are valid and kept. The "model" key is non-empty and preserved.
+        props = {k: v for k, v in props.items() if v != "" and v is not None}
+
         # Helper to get port by name. The editor annotates every port with
         # a net — disconnected pins get their own generated netN — so the
         # lookup is total. Built-in device symbols label pins with uppercase

--- a/python/nyancad/pyproject.toml
+++ b/python/nyancad/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 dependencies = [
     "anywidget>=0.9.0",
     "traitlets",
-    "InSpice[vacask]",
+    "InSpice",
+    'vacask-bin>=0.3.0; platform_machine != "wasm32"',
     "holoviews",
 ]
 

--- a/python/nyancad/tests/test_netlist.py
+++ b/python/nyancad/tests/test_netlist.py
@@ -499,23 +499,27 @@ class TestLibrarySectionEntry:
         }
 
     def test_emits_lib_with_default_corner(self):
-        """No corner preference → first section, emitted as a real `.lib` line,
-        with no leftover `{corner}` template token.
+        """No corner preference → first section, emitted as a real `.lib` line
+        pointing at the resolved local cache path, with no leftover `{corner}`
+        template token.
         """
         spice = str(NyanCircuit("top", self._schem()))
-        assert "pdk.zip#sky130.lib.spice tt" in spice
+        assert "nyancad_archive_cache" in spice
+        assert "sky130.lib.spice tt" in spice
         assert "{corner}" not in spice
 
     def test_corner_preference_selects_section(self):
         spice = str(
             NyanCircuit("top", self._schem(sections=("ss", "tt", "ff")), corners=["ff"])
         )
-        assert "pdk.zip#sky130.lib.spice ff" in spice
+        assert "nyancad_archive_cache" in spice
+        assert "sky130.lib.spice ff" in spice
 
     def test_include_when_no_sections(self):
         """A model entry without sections falls back to `.include` (no corner)."""
         spice = str(NyanCircuit("top", self._schem(drop_sections=True)))
         assert ".include" in spice
+        assert "nyancad_archive_cache" in spice
         assert ".lib " not in spice
         assert "{corner}" not in spice
 
@@ -523,6 +527,28 @@ class TestLibrarySectionEntry:
         """The subcircuit X-call lists nets in the entry's port-order."""
         spice = str(NyanCircuit("top", self._schem()))
         assert "d g s b sky130_fd_pr__nfet_01v8" in spice
+
+    def test_registers_pending_download(self):
+        """The structured `library` URL is registered for download: archive URL
+        (without fragment) + entrypoint extracted from the URL fragment.
+        """
+        circuit = NyanCircuit("top", self._schem())
+        urls = [url for url, _dest, _entry in circuit._pending_downloads]
+        assert "https://example.com/pdk.zip" in urls
+        entrypoints = {
+            url: entry for url, _dest, entry in circuit._pending_downloads
+        }
+        assert entrypoints["https://example.com/pdk.zip"] == "sky130.lib.spice"
+
+    def test_bare_local_library_passthrough(self):
+        """A non-URL `library` is emitted unchanged and registers no download."""
+        schem = self._schem()
+        schem["models"]["models:sky.nfet"]["models"][0]["library"] = "models/foo.lib"
+        circuit = NyanCircuit("top", schem)
+        spice = str(circuit)
+        assert "models/foo.lib tt" in spice
+        assert "nyancad_archive_cache" not in spice
+        assert circuit._pending_downloads == []
 
 
 # ---------------------------------------------------------------------------

--- a/python/nyancad/tests/test_netlist.py
+++ b/python/nyancad/tests/test_netlist.py
@@ -552,6 +552,70 @@ class TestLibrarySectionEntry:
 
 
 # ---------------------------------------------------------------------------
+# Case-insensitive port matching — built-in symbols vs. migrated model ports
+# ---------------------------------------------------------------------------
+
+
+class TestCaseInsensitivePorts:
+    """Built-in nmos/pmos symbols label pins with uppercase chars (D/G/S/B),
+    but PDK models migrated by SpiceArmyKnife.jl declare ports/port-order in
+    lowercase (sky130 subckts use ``d g s b``). SPICE is case-insensitive, so
+    the X-call must still resolve each model port to the right device net
+    regardless of case.
+    """
+
+    def _schem(self, *, port_order, ports):
+        """nmos device with uppercase nets against a model whose port names
+        and port-order are given by the caller (typically lowercase).
+        """
+        return {
+            "top": {
+                "top:M1": {
+                    "_id": "top:M1",
+                    "type": "nmos",
+                    "name": "M1",
+                    "model": "sky.nfet",
+                    "nets": {"D": "nd", "G": "ng", "S": "ns", "B": "nb"},
+                }
+            },
+            "models": {
+                "models:sky.nfet": {
+                    "name": "sky130_fd_pr__nfet_01v8_lvt",
+                    "type": "nmos",
+                    "ports": [{"name": n, "side": "left"} for n in ports],
+                    "models": [
+                        {
+                            "language": "spice",
+                            "name": "sky130_fd_pr__nfet_01v8_lvt",
+                            "spice-type": "SUBCKT",
+                            "library": "models/sky130.lib.spice",
+                            "sections": ["tt"],
+                            "port-order": port_order,
+                        }
+                    ],
+                }
+            },
+        }
+
+    def test_lowercase_port_order_resolves_uppercase_nets(self):
+        """Lowercase ``port-order`` maps onto uppercase device nets in order."""
+        schem = self._schem(
+            port_order=["d", "g", "s", "b"], ports=["d", "g", "s", "b"]
+        )
+        spice = str(NyanCircuit("top", schem))
+        assert "nd ng ns nb sky130_fd_pr__nfet_01v8_lvt" in spice
+
+    def test_lowercase_default_port_order_resolves_uppercase_nets(self):
+        """With no explicit port-order, the alphabetical default of the
+        lowercase model ports still resolves against uppercase nets.
+        """
+        schem = self._schem(port_order=None, ports=["d", "g", "s", "b"])
+        # default_port_order sorts by name: b, d, g, s
+        spice = str(NyanCircuit("top", schem))
+        assert "nb nd ng ns sky130_fd_pr__nfet_01v8_lvt" in spice
+
+
+# ---------------------------------------------------------------------------
 # populate_from_nyancad — reads :nets off each device
 # ---------------------------------------------------------------------------
 

--- a/python/nyancad/tests/test_netlist.py
+++ b/python/nyancad/tests/test_netlist.py
@@ -616,6 +616,83 @@ class TestCaseInsensitivePorts:
 
 
 # ---------------------------------------------------------------------------
+# Empty prop values are dropped — no invalid `param=` tokens
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyPropsDropped:
+    """Devices placed before commit 086820d (and any still in CouchDB) carry a
+    dense `:props` map where every model param was pre-filled with "". An empty
+    override is meaningless to SPICE: emitting ``w=`` is invalid and clobbers the
+    subckt's own default. The netlister must drop empty values before expanding
+    them as ``**props`` kwargs.
+    """
+
+    def _schem(self, props):
+        """pmos device against a SUBCKT model (IHP sg13_lv_pmos shape), with the
+        caller-supplied device props.
+        """
+        return {
+            "top": {
+                "top:M2": {
+                    "_id": "top:M2",
+                    "type": "pmos",
+                    "name": "M2",
+                    "model": "pdk.pmos",
+                    "nets": {"D": "nd", "G": "ng", "S": "ns", "B": "nb"},
+                    "props": props,
+                }
+            },
+            "models": {
+                "models:pdk.pmos": {
+                    "name": "sg13_lv_pmos",
+                    "type": "pmos",
+                    "ports": [
+                        {"name": n, "side": "left"} for n in ("d", "g", "s", "b")
+                    ],
+                    # Params with no defaults (the SpiceArmyKnife migration shape)
+                    "props": [{"name": k} for k in ("w", "l", "ad", "as")],
+                    "models": [
+                        {
+                            "language": "spice",
+                            "name": "sg13_lv_pmos",
+                            "spice-type": "SUBCKT",
+                            "library": "models/sg13g2.lib.spice",
+                            "port-order": ["d", "g", "s", "b"],
+                        }
+                    ],
+                }
+            },
+        }
+
+    def test_all_empty_props_emit_no_param_tokens(self):
+        """A device whose props are all "" produces an X-line with no
+        ``param=`` fragments — just the instance, nets and subckt name.
+        """
+        spice = str(
+            NyanCircuit("top", self._schem({"w": "", "l": "", "ad": "", "as": ""}))
+        )
+        assert "sg13_lv_pmos" in spice
+        # No empty `param=` fragments for any of the model params
+        assert " w=" not in spice
+        assert " l=" not in spice
+        assert " ad=" not in spice
+        assert " as=" not in spice
+        # And no bare empty-value token anywhere (e.g. "w= " or a trailing "=")
+        assert "= " not in spice
+        assert not any(line.rstrip().endswith("=") for line in spice.splitlines())
+
+    def test_real_value_still_emitted(self):
+        """A param with a real value survives the empty-drop and is emitted."""
+        spice = str(
+            NyanCircuit("top", self._schem({"w": "0.35u", "l": "", "ad": "", "as": ""}))
+        )
+        assert "w=0.35u" in spice
+        assert " l=" not in spice
+        assert " ad=" not in spice
+
+
+# ---------------------------------------------------------------------------
 # populate_from_nyancad — reads :nets off each device
 # ---------------------------------------------------------------------------
 

--- a/python/nyancad/tests/test_netlist.py
+++ b/python/nyancad/tests/test_netlist.py
@@ -451,6 +451,81 @@ class TestModelPropDefaultsFallback:
 
 
 # ---------------------------------------------------------------------------
+# Structured library + sections model entries (Cadnip :lib/:include migration)
+# ---------------------------------------------------------------------------
+
+
+class TestLibrarySectionEntry:
+    """A PDK model migrated to the new schema carries a structured ``library``
+    (+ optional ``sections``) model entry instead of inline ``.lib … {corner}``
+    code. The circuit must emit a ``.lib library section`` / ``.include library``
+    line — with the corner chosen by :func:`_select_corner`, not a baked-in
+    ``{corner}`` token — and order the X-call pins by ``port-order``.
+    """
+
+    def _schem(self, sections=("tt",), drop_sections=False):
+        entry = {
+            "language": "spice",
+            "name": "sky130_fd_pr__nfet_01v8",
+            "spice-type": "SUBCKT",
+            "library": "https://example.com/pdk.zip#sky130.lib.spice",
+            "port-order": ["D", "G", "S", "B"],
+        }
+        if not drop_sections:
+            entry["sections"] = list(sections)
+        return {
+            "top": {
+                "top:X1": {
+                    "_id": "top:X1",
+                    "type": "nmos",
+                    "name": "X1",
+                    "model": "sky.nfet",
+                    "nets": {"D": "d", "G": "g", "S": "s", "B": "b"},
+                }
+            },
+            "models": {
+                "models:sky.nfet": {
+                    "name": "sky130_fd_pr__nfet_01v8",
+                    "type": "nmos",
+                    "ports": [
+                        {"name": "D", "side": "top"},
+                        {"name": "G", "side": "left"},
+                        {"name": "S", "side": "bottom"},
+                        {"name": "B", "side": "right"},
+                    ],
+                    "models": [entry],
+                }
+            },
+        }
+
+    def test_emits_lib_with_default_corner(self):
+        """No corner preference → first section, emitted as a real `.lib` line,
+        with no leftover `{corner}` template token.
+        """
+        spice = str(NyanCircuit("top", self._schem()))
+        assert "pdk.zip#sky130.lib.spice tt" in spice
+        assert "{corner}" not in spice
+
+    def test_corner_preference_selects_section(self):
+        spice = str(
+            NyanCircuit("top", self._schem(sections=("ss", "tt", "ff")), corners=["ff"])
+        )
+        assert "pdk.zip#sky130.lib.spice ff" in spice
+
+    def test_include_when_no_sections(self):
+        """A model entry without sections falls back to `.include` (no corner)."""
+        spice = str(NyanCircuit("top", self._schem(drop_sections=True)))
+        assert ".include" in spice
+        assert ".lib " not in spice
+        assert "{corner}" not in spice
+
+    def test_xcall_orders_pins_by_port_order(self):
+        """The subcircuit X-call lists nets in the entry's port-order."""
+        spice = str(NyanCircuit("top", self._schem()))
+        assert "d g s b sky130_fd_pr__nfet_01v8" in spice
+
+
+# ---------------------------------------------------------------------------
 # populate_from_nyancad — reads :nets off each device
 # ---------------------------------------------------------------------------
 

--- a/src/bash/view.json
+++ b/src/bash/view.json
@@ -6,9 +6,9 @@
     }
   },
   "indexes": {
-    "category-type-index": {
+    "tags-type-index": {
       "index": {
-        "fields": ["category", "type"]
+        "fields": ["tags", "type"]
       },
       "type": "json"
     }

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -372,8 +372,8 @@
   [model-def]
   (when model-def
     (not-empty
-      (into {} (for [p (:props model-def) :when (:name p)]
-                 [(:name p) (or (:default p) "")])))))
+      (into {} (for [p (:props model-def) :when (and (:name p) (some? (:default p)))]
+                 [(:name p) (:default p)])))))
 
 (defn schema->field-type
   "Convert a nyanlib prop (carrying optional :schema from JSON Schema) into a

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -373,7 +373,7 @@
   (when model-def
     (not-empty
       (into {} (for [p (:props model-def) :when (and (:name p) (some? (:default p)))]
-                 [(:name p) (:default p)])))))
+                 [(keyword (:name p)) (:default p)])))))
 
 (defn schema->field-type
   "Convert a nyanlib prop (carrying optional :schema from JSON Schema) into a

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -2179,10 +2179,9 @@
                                           [model-selector-popup @device-type
                                            (fn [model-id]
                                              (reset! model (if model-id (cm/bare-id model-id) ""))
-                                             (when model-id
-                                               (when-let [mdef (get @modeldb model-id)]
-                                                 (when-let [defaults (cm/model-prop-defaults mdef)]
-                                                   (swap! props (fn [m] (merge defaults m))))))
+                                             (let [mdef (when model-id (get @modeldb model-id))
+                                                   defaults (or (cm/model-prop-defaults mdef) {})]
+                                               (reset! props defaults))
                                              (post-action!))]))}
             [cm/search]]]
           ; Get properties from built-in device and model

--- a/src/test/nyancad/mosaic/common_test.cljc
+++ b/src/test/nyancad/mosaic/common_test.cljc
@@ -408,12 +408,12 @@
   (is (nil? (cm/model-prop-defaults {:props []}))))
 
 (deftest model-prop-defaults-with-named-props
-  (is (= {"length" "10"}
+  (is (= {:length "10"}
          (cm/model-prop-defaults {:props [{:name "length" :default "10"}
                                           {:name "width"}]}))))
 
 (deftest model-prop-defaults-skips-nameless
-  (is (= {"a" "1"}
+  (is (= {:a "1"}
          (cm/model-prop-defaults {:props [{:name "a" :default "1"}
                                           {:tooltip "orphan"}]}))))
 

--- a/src/test/nyancad/mosaic/common_test.cljc
+++ b/src/test/nyancad/mosaic/common_test.cljc
@@ -396,8 +396,10 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; Contract: given a model definition with :props, return a map of
-;; {prop-name → default-value}. nil model-def → nil. Empty :props → nil.
-;; Props missing :name are skipped. Missing :default falls back to "".
+;; {prop-name → default-value} for props that carry a non-nil :default. nil
+;; model-def → nil. Empty :props → nil. Props missing :name are skipped. Props
+;; without a :default (or :default nil) are omitted entirely — they must not be
+;; materialized as empty overrides into the device doc.
 
 (deftest model-prop-defaults-nil-model
   (is (nil? (cm/model-prop-defaults nil))))
@@ -406,7 +408,7 @@
   (is (nil? (cm/model-prop-defaults {:props []}))))
 
 (deftest model-prop-defaults-with-named-props
-  (is (= {"length" "10" "width" ""}
+  (is (= {"length" "10"}
          (cm/model-prop-defaults {:props [{:name "length" :default "10"}
                                           {:name "width"}]}))))
 
@@ -415,9 +417,8 @@
          (cm/model-prop-defaults {:props [{:name "a" :default "1"}
                                           {:tooltip "orphan"}]}))))
 
-(deftest model-prop-defaults-nil-default-falls-back
-  (is (= {"x" ""}
-         (cm/model-prop-defaults {:props [{:name "x" :default nil}]}))))
+(deftest model-prop-defaults-nil-default-excluded
+  (is (nil? (cm/model-prop-defaults {:props [{:name "x" :default nil}]}))))
 
 ;; ---------------------------------------------------------------------------
 ;; format — template interpolation via JS Function


### PR DESCRIPTION
## Summary
- `src/bash/view.json`: rename Mango index `category-type-index` → `tags-type-index` and change fields `["category","type"]` → `["tags","type"]`, matching the model-definition schema migration (`category`→`tags`). Deployed to the live `_design/models` by Mosaic CI; Cadnip only preserves it.
- `tests/test_netlist.py`: add `TestLibrarySectionEntry` covering a PDK model migrated to a structured `library` + `sections` entry — asserts a real `.lib library section` / `.include library` line (corner chosen by `_select_corner`, no `{corner}` token) and X-call pins ordered by `port-order`.

## Test Plan
- [x] `TestLibrarySectionEntry` + `TestSelectCorner` pass (corner default/preference/include-fallback, pin order, no `{corner}`)
- [x] `test_schemas.py` (23) passes
- [ ] **Manual (needs CouchDB):** after deploying `view.json`, `POST /models/_find` with a `tags` selector and confirm `explain` uses `tags-type-index`

## Notes
- Companion Cadnip PR migrates the generator output to the new schema (`tags`, flat `models`/`ports`, structured `library`/`sections`).
- **Caught during verification (follow-up, not in this PR):** `netlist.py:698-703` calls `self.lib`/`self.include` directly for structured-`library` entries, which does NOT run the URL→cache download resolution the inline-`code` path gets via `resolve_url_includes`. So `http(s)` library URLs get handed to InSpice as local file paths. Needs a separate fix routing `library` URLs through the `_pending_downloads`/`resolve_url_includes` pipeline.