### PR TITLE
Restore Catppuccin Mocha fallback colors in CSS

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -13,35 +13,35 @@ html {
 :root {
     color-scheme: light dark;
 
-    /* Chrome — derived from VS Code theme variables */
+    /* Chrome — VS Code theme with Catppuccin Mocha fallbacks */
     --color-bg: var(--vscode-editor-background, light-dark(#f9f9f9, #1e1e2e));
-    --color-surface: var(--vscode-sideBar-background, light-dark(white, #252526));
-    --color-surface-alt: var(--vscode-sideBarSectionHeader-background, light-dark(#f8f8f8, #37373d));
-    --color-text: var(--vscode-foreground, light-dark(#222222a5, #cccccc));
-    --color-text-strong: var(--vscode-editor-foreground, light-dark(#222222, #d4d4d4));
-    --color-text-muted: var(--vscode-descriptionForeground, light-dark(#666, #717171));
-    --color-border: var(--vscode-sideBarSectionHeader-border, light-dark(lightgray, #3c3c3c));
-    --color-border-light: var(--vscode-sideBar-border, light-dark(#e7e7e7, #1e1e1e));
+    --color-surface: var(--vscode-sideBar-background, light-dark(white, #313244));
+    --color-surface-alt: var(--vscode-sideBarSectionHeader-background, light-dark(#f8f8f8, #45475a));
+    --color-text: var(--vscode-foreground, light-dark(#222222a5, #cdd6f4a5));
+    --color-text-strong: var(--vscode-editor-foreground, light-dark(#222222, #cdd6f4));
+    --color-text-muted: var(--vscode-descriptionForeground, light-dark(#666, #a6adc8));
+    --color-border: var(--vscode-sideBarSectionHeader-border, light-dark(lightgray, #585b70));
+    --color-border-light: var(--vscode-sideBar-border, light-dark(#e7e7e7, #313244));
     --color-shadow: light-dark(#00000033, #00000066);
-    --color-accent: var(--vscode-button-background, light-dark(#0e1a32, #0078d4));
-    --color-accent-text: var(--vscode-button-foreground, light-dark(white, #ffffff));
-    --color-input-bg: var(--vscode-input-background, light-dark(#00000008, #1e1e1e));
-    --color-input-border: var(--vscode-input-border, light-dark(#2222220d, #3c3c3c));
-    --color-hover: var(--vscode-list-hoverBackground, light-dark(#00000007, #2a2d2e));
+    --color-accent: var(--vscode-button-background, light-dark(#0e1a32, #89b4fa));
+    --color-accent-text: var(--vscode-button-foreground, light-dark(white, #1e1e2e));
+    --color-input-bg: var(--vscode-input-background, light-dark(#00000008, #1e1e2e));
+    --color-input-border: var(--vscode-input-border, light-dark(#2222220d, #585b70));
+    --color-hover: var(--vscode-list-hoverBackground, light-dark(#00000007, #45475a));
 
-    /* Canvas — mirrors Livewire's VS Code theme derivation */
-    --canvas-bg: var(--vscode-editor-background, light-dark(#f9f9f9, #1e1e1e));
-    --canvas-grid: var(--vscode-panel-border, light-dark(lightgray, #555555));
-    --canvas-stroke: var(--vscode-editor-foreground, light-dark(black, #d4d4d4));
-    --canvas-wire-stroke: var(--vscode-editor-foreground, light-dark(black, #d4d4d4));
-    --canvas-wire-photonic: var(--vscode-editor-foreground, light-dark(black, #d4d4d4));
-    --canvas-text: var(--vscode-editor-foreground, light-dark(#444, #d4d4d4));
-    --canvas-text-muted: var(--vscode-descriptionForeground, light-dark(#666, #717171));
-    --canvas-select: color-mix(in srgb, var(--vscode-focusBorder, light-dark(#6688cc, #007fd4)) 25%, var(--canvas-bg));
+    /* Canvas — VS Code theme with Catppuccin Mocha fallbacks */
+    --canvas-bg: var(--vscode-editor-background, light-dark(#f9f9f9, #1e1e2e));
+    --canvas-grid: var(--vscode-panel-border, light-dark(lightgray, #313244));
+    --canvas-stroke: var(--vscode-editor-foreground, light-dark(black, #cdd6f4));
+    --canvas-wire-stroke: var(--vscode-editor-foreground, light-dark(black, #89b4fa));
+    --canvas-wire-photonic: var(--vscode-editor-foreground, light-dark(black, #94e2d5));
+    --canvas-text: var(--vscode-editor-foreground, light-dark(#444, #cdd6f4));
+    --canvas-text-muted: var(--vscode-descriptionForeground, light-dark(#666, #a6adc8));
+    --canvas-select: color-mix(in srgb, var(--vscode-focusBorder, light-dark(#6688cc, #ba7eee)) 25%, var(--canvas-bg));
     --canvas-nc: light-dark(red, #f38ba8);
     --canvas-error: light-dark(red, #f38ba8);
     --canvas-warning: light-dark(orange, #fab387);
-    --canvas-placeholder: var(--vscode-descriptionForeground, light-dark(#888, #717171));
+    --canvas-placeholder: var(--vscode-descriptionForeground, light-dark(#888, #6c7086));
     --canvas-port-electric-fill: light-dark(rgb(145, 0, 0), #f38ba8);
     --canvas-port-electric-stroke: light-dark(rgb(53, 0, 0), #f38ba8);
     --canvas-port-photonic-fill: light-dark(rgb(0, 80, 160), #89b4fa);

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -37,7 +37,7 @@ html {
     --canvas-wire-photonic: var(--vscode-editor-foreground, light-dark(black, #94e2d5));
     --canvas-text: var(--vscode-editor-foreground, light-dark(#444, #cdd6f4));
     --canvas-text-muted: var(--vscode-descriptionForeground, light-dark(#666, #a6adc8));
-    --canvas-select: color-mix(in srgb, var(--vscode-focusBorder, light-dark(#6688cc, #ba7eee)) 25%, var(--canvas-bg));
+    --canvas-select: light-dark(rgb(229, 216, 243), #45365e);
     --canvas-nc: light-dark(red, #f38ba8);
     --canvas-error: light-dark(red, #f38ba8);
     --canvas-warning: light-dark(orange, #fab387);
@@ -1137,6 +1137,11 @@ rect.select {
 .dark-cursors .mosaic-canvas.eraser .device,
 .vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.eraser .wire:hover,
 .vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.eraser .device { cursor: url(icons/eraser-light.svg) 6 14, crosshair; }
+
+body.vscode-dark,
+body.vscode-light {
+    --canvas-select: color-mix(in srgb, var(--vscode-focusBorder) 25%, var(--canvas-bg));
+}
 
 body.vscode-dark .mosaic-container .menu .status,
 body.vscode-light .mosaic-container .menu .status {


### PR DESCRIPTION
## Summary

Restores Catppuccin Mocha dark-mode fallback colors in CSS custom properties that were accidentally replaced with VS Code Dark+ defaults in commit 4a94acc. VS Code theming still works via var(--vscode-...) which takes precedence when set.

## Changes

- **Wire stroke fallback**: Restored from #d4d4d4 (gray) to #89b4fa (Catppuccin blue)
- **Photonic wire fallback**: Restored from #d4d4d4 (gray) to #94e2d5 (Catppuccin teal)
- **Selection highlight**: Restored to original purple light-dark(rgb(229, 216, 243), #45365e) on web; color-mix from vscode-focusBorder in VS Code
- **Chrome colors**: All surface, text, border, accent, and hover colors restored to Catppuccin Mocha palette
- **Canvas selection split**: --canvas-select now gives web standalone the original purple verbatim, while VS Code derives it from --vscode-focusBorder via color-mix