### PR TITLE
Add ruff linting, pre-commit hooks, and CI enforcement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,18 @@ env:
   MOSAIC_ROOT: '.'
 
 jobs:
+  lint:
+    name: Lint 🧹
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: 'format --check'
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: 'check'
+
   # Fast Python unit tests — no Docker, no JS build, no native deps.
   # Future test jobs (CLJS unit, Python integration with CouchDB, Playwright E2E)
   # will be added as parallel jobs alongside this one. See testing-plan.md.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: debug-statements
+      - id: mixed-line-ending
+      - id: name-tests-test
+        args: ['--pytest-test-first']
+      - id: trailing-whitespace
+        args: ['--markdown-linebreak-ext=md']
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.0
+    hooks:
+      - id: ruff-format
+        types_or: [python, jupyter, pyi]
+      - id: ruff-check
+        types_or: [python, pyi]
+        args: ['--fix']

--- a/python/nyancad-server/pyproject.toml
+++ b/python/nyancad-server/pyproject.toml
@@ -7,7 +7,7 @@ name = "nyancad-server"
 version = "0.19.0"
 description = "NyanCAD server package with marimo integration"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 license = "MPL-2.0"
 authors = [
     {name = "Pepijn de Vos", email = "me@pepijndevos.nl"},
@@ -16,11 +16,8 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "marimo>=0.19.0",

--- a/python/nyancad/nyancad/netlist.py
+++ b/python/nyancad/nyancad/netlist.py
@@ -775,7 +775,8 @@ class NyanCircuit(NyanCADMixin, Circuit):
     def _resolve_url(self, path_str):
         """Resolve an http(s) library/include URL to a local cache path and register
         the archive for download. Returns the resolved Path, or None when path_str is
-        not an http(s) URL (caller keeps the original path)."""
+        not an http(s) URL (caller keeps the original path).
+        """
         parsed = urlparse(path_str)
         if parsed.scheme not in ("http", "https"):
             return None
@@ -787,7 +788,9 @@ class NyanCircuit(NyanCADMixin, Circuit):
         cached_file = cache_dir / f"{url_hash}_{Path(parsed.path).name}"
         if not cached_file.exists():
             self._pending_downloads.append((archive_url, cached_file, entrypoint))
-        return (cache_dir / cached_file.stem / entrypoint) if entrypoint else cached_file
+        return (
+            (cache_dir / cached_file.stem / entrypoint) if entrypoint else cached_file
+        )
 
 
 class NyanSubCircuit(NyanCADMixin, SubCircuit):

--- a/python/nyancad/pyproject.toml
+++ b/python/nyancad/pyproject.toml
@@ -7,7 +7,7 @@ name = "nyancad"
 version = "0.17.1"
 description = "NyanCAD Python library for schematic editor with anywidget integration"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 license = "MPL-2.0"
 authors = [
     {name = "Pepijn de Vos", email = "me@pepijndevos.nl"},
@@ -16,11 +16,8 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "anywidget>=0.9.0",

--- a/python/nyancad/tests/test_netlist.py
+++ b/python/nyancad/tests/test_netlist.py
@@ -535,9 +535,7 @@ class TestLibrarySectionEntry:
         circuit = NyanCircuit("top", self._schem())
         urls = [url for url, _dest, _entry in circuit._pending_downloads]
         assert "https://example.com/pdk.zip" in urls
-        entrypoints = {
-            url: entry for url, _dest, entry in circuit._pending_downloads
-        }
+        entrypoints = {url: entry for url, _dest, entry in circuit._pending_downloads}
         assert entrypoints["https://example.com/pdk.zip"] == "sky130.lib.spice"
 
     def test_bare_local_library_passthrough(self):
@@ -565,7 +563,7 @@ class TestCaseInsensitivePorts:
     """
 
     def _schem(self, *, port_order, ports):
-        """nmos device with uppercase nets against a model whose port names
+        """Nmos device with uppercase nets against a model whose port names
         and port-order are given by the caller (typically lowercase).
         """
         return {
@@ -599,9 +597,7 @@ class TestCaseInsensitivePorts:
 
     def test_lowercase_port_order_resolves_uppercase_nets(self):
         """Lowercase ``port-order`` maps onto uppercase device nets in order."""
-        schem = self._schem(
-            port_order=["d", "g", "s", "b"], ports=["d", "g", "s", "b"]
-        )
+        schem = self._schem(port_order=["d", "g", "s", "b"], ports=["d", "g", "s", "b"])
         spice = str(NyanCircuit("top", schem))
         assert "nd ng ns nb sky130_fd_pr__nfet_01v8_lvt" in spice
 
@@ -629,7 +625,7 @@ class TestEmptyPropsDropped:
     """
 
     def _schem(self, props):
-        """pmos device against a SUBCKT model (IHP sg13_lv_pmos shape), with the
+        """Pmos device against a SUBCKT model (IHP sg13_lv_pmos shape), with the
         caller-supplied device props.
         """
         return {

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,118 @@
+target-version = "py312"
+
+[format]
+docstring-code-format = true
+
+[lint]
+select = ["ALL"]
+ignore = [
+    # Path-related
+    "PTH",
+    # Fixme comments
+    "FIX",
+    # Commented-out code (ERA)
+    "ERA",
+    # Trailing comma (conflicts with formatter)
+    "COM812",
+    # TODO formatting
+    "TD001",
+    "TD002",
+    "TD003",
+    # Banned relative imports
+    "TID252",
+    # Use of assert
+    "S101",
+    # Too many statements / branches / complexity
+    "PLR0915",
+    "PLR0912",
+    "C901",
+    # Dynamically typed expressions (typing.Any)
+    "ANN401",
+    # Unused function argument
+    "ARG001",
+    # Too many arguments
+    "PLR0913",
+    # f-string in logging
+    "G004",
+    # Partial executable path / subprocess shell
+    "S607",
+    "S602",
+    "S603",
+    # Typing-only import (move into TYPE_CHECKING)
+    "TC002",
+    # Missing type annotations (not yet enforced project-wide)
+    "ANN001",
+    "ANN002",
+    "ANN003",
+    "ANN201",
+    "ANN202",
+    "ANN205",
+    "ANN206",
+    # Docstring rules not yet enforced project-wide
+    "D100",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D107",
+    "D205",
+    "D301",
+    "D415",
+    "D417",
+    # Magic value comparison
+    "PLR2004",
+    # Import outside top-level (common in lazy/conditional imports)
+    "PLC0415",
+    # Private member access (common in tests)
+    "SLF001",
+    # Blind except
+    "BLE001",
+    # Boolean positional argument
+    "FBT001",
+    "FBT002",
+    # Ambiguous unicode
+    "RUF002",
+    # Mutable class default
+    "RUF012",
+    # Builtin shadowing (type, id used as parameter names)
+    "A002",
+    # Unused method arguments (marimo cell dependency tracking)
+    "ARG002",
+    # Useless expression (marimo cell return values)
+    "B018",
+    # Missing class docstring
+    "D101",
+    # Exception with string literal
+    "EM101",
+    # Exception with f-string literal
+    "EM102",
+    # Non-lowercase argument (scientific naming)
+    "N803",
+    # Non-lowercase variable (scientific naming)
+    "N806",
+    # Too many return statements
+    "PLR0911",
+    # Useless return (marimo cell output suppression)
+    "PLR1711",
+    # Collection concatenation
+    "RUF005",
+    # try-except-pass
+    "S110",
+    # Ternary instead of if-else
+    "SIM108",
+    # Print found (CLI tools, notebooks, server startup)
+    "T201",
+    # Long exception messages
+    "TRY003",
+    # Consider else block
+    "TRY300",
+    # Abstract raise
+    "TRY301",
+]
+exclude = ["docs/*", "build/*", "node_modules/*", "out/*", ".venv/*", "public/*"]
+
+[lint.isort]
+known-third-party = ["marimo"]
+
+[lint.pydocstyle]
+convention = "google"


### PR DESCRIPTION
## Summary

- Add `ruff.toml` with formatting and linting rules (adapted from gdsfactory+)
- Add `.pre-commit-config.yaml` with ruff format/check and standard pre-commit hooks
- Add `lint` CI job using `astral-sh/ruff-action@v3` for `format --check` and `check`
- Bump `requires-python` from `>=3.8` to `>=3.12` in both Python packages (kfnetlist already requires 3.12, CI tests on 3.12 only)
- Auto-fix residual formatting drift in 7 Python files

## Motivation

GDSFactory+ vendors Mosaic via `git subrepo` and enforces ruff formatting through its own pre-commit hooks. Without linting infrastructure upstream, formatting drifts with every contribution and has to be re-fixed on each sync. This PR adds the same linting config upstream so both repos stay in sync automatically.

## Test plan

- [x] `ruff format --check .` passes
- [x] `ruff check .` passes
- [x] `pytest python/nyancad/tests -v` — 120 tests pass
- [x] `pytest python/nyancad-server/tests -v` — 22 tests pass