### PR TITLE
feat: structured transient source parameters and VACASK support

### DIFF
--- a/python/nyancad/nyancad/netlist.py
+++ b/python/nyancad/nyancad/netlist.py
@@ -14,6 +14,16 @@ from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import urlparse
 
+from InSpice.Spice.HighLevelElement import (
+    ExponentialCurrentSource,
+    ExponentialVoltageSource,
+    PulseCurrentSource,
+    PulseVoltageSource,
+    SingleFrequencyFMCurrentSource,
+    SingleFrequencyFMVoltageSource,
+    SinusoidalCurrentSource,
+    SinusoidalVoltageSource,
+)
 from InSpice.Spice.Netlist import Circuit, SubCircuit
 from InSpice.Spice.Parser.HighLevelParser import SpiceSource
 from InSpice.Spice.Parser.Translator import Builder
@@ -116,6 +126,112 @@ def _select_corner(sections, corners):
 IDENTIFIER_RE = re.compile(r"\b[A-Za-z_]\w*", re.ASCII)
 VALID_IDENT_RE = re.compile(r"^[A-Za-z_]\w*$", re.ASCII)
 STRUCTURAL_TYPES = {"wire", "text", "port", "polyline", "via", "taper", "net"}
+
+_SIM_LANGUAGES = {
+    "ngspice": ("spice",),
+    "xyce": ("spice",),
+    "vacask": ("spectre",),
+}
+
+_SPICE_SUFFIX_SCALE = {
+    "t": 1e12,
+    "g": 1e9,
+    "meg": 1e6,
+    "k": 1e3,
+    "mil": 25.4e-6,
+    "m": 1e-3,
+    "u": 1e-6,
+    "n": 1e-9,
+    "p": 1e-12,
+    "f": 1e-15,
+}
+_SPICE_NUMBER_RE = re.compile(
+    r"^([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)\s*(\w*)$", re.IGNORECASE
+)
+
+
+def _parse_spice_value(s):
+    """Convert a SPICE engineering-notation string to a float.
+
+    Handles suffixes like ``1k`` (1e3), ``10n`` (1e-8), ``4.7Meg`` (4.7e6),
+    and plain numeric strings. Returns None for None or empty strings.
+    """
+    if s is None or (isinstance(s, str) and not s.strip()):
+        return None
+    if isinstance(s, (int, float)):
+        return float(s)
+    s = s.strip()
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    m = _SPICE_NUMBER_RE.match(s)
+    if not m:
+        return None
+    num_str, suffix = m.group(1), m.group(2)
+    scale = _SPICE_SUFFIX_SCALE.get(suffix.lower())
+    if scale is None and suffix:
+        # Try "meg" prefix match for case variations like "Meg", "MEG"
+        if suffix.lower().startswith("meg"):
+            scale = 1e6
+        else:
+            return None
+    return float(num_str) * (scale if scale is not None else 1.0)
+
+
+_TRAN_SOURCE_CLASSES = {
+    "sin": {
+        "voltage": SinusoidalVoltageSource,
+        "current": SinusoidalCurrentSource,
+    },
+    "pulse": {
+        "voltage": PulseVoltageSource,
+        "current": PulseCurrentSource,
+    },
+    "exp": {
+        "voltage": ExponentialVoltageSource,
+        "current": ExponentialCurrentSource,
+    },
+    "sffm": {
+        "voltage": SingleFrequencyFMVoltageSource,
+        "current": SingleFrequencyFMCurrentSource,
+    },
+}
+
+_TRAN_PARAM_MAP = {
+    "sin": {
+        "offset": "offset",
+        "amplitude": "amplitude",
+        "frequency": "frequency",
+        "delay": "delay",
+        "damping": "damping_factor",
+    },
+    "pulse": {
+        "initial": "initial_value",
+        "pulsed": "pulsed_value",
+        "width": "pulse_width",
+        "period": "period",
+        "delay": "delay_time",
+        "rise": "rise_time",
+        "fall": "fall_time",
+    },
+    "exp": {
+        "initial": "initial_value",
+        "pulsed": "pulsed_value",
+        "rise-delay": "rise_delay_time",
+        "rise-tau": "rise_time_constant",
+        "fall-delay": "fall_delay_time",
+        "fall-tau": "fall_time_constant",
+    },
+    "sffm": {
+        "offset": "offset",
+        "amplitude": "amplitude",
+        "carrier-freq": "carrier_frequency",
+        "mod-index": "modulation_index",
+        "signal-freq": "signal_frequency",
+    },
+}
+
 
 
 def _eval_params(entry_params, device_props, sim="NgSpice"):
@@ -445,25 +561,57 @@ class NyanCADMixin:
     """Mixin providing NyanCAD integration for InSpice netlist objects."""
 
     def _select_model_entry(self, model_def, sim):
-        """Select a SPICE model entry from the flat models list.
+        """Select a model entry compatible with the target simulator.
 
-        Reads from model_def['models'] (flat list), filters for language=='spice',
-        and matches by implementation name (case-insensitive).
-
-        Returns:
-            dict: selected model entry or None if no SPICE entries
+        Each simulator only accepts specific languages (see ``_SIM_LANGUAGES``).
+        Priority: exact implementation match first, then first language-compatible
+        entry. Returns None when no compatible entry exists.
         """
         entries = model_def.get("models", [])
-        spice_entries = [e for e in entries if e.get("language") == "spice"]
-        if not spice_entries:
+        if not entries:
             return None
-
-        # Look for implementation matching sim parameter, fallback to first spice entry
-        for entry in spice_entries:
+        accepted = _SIM_LANGUAGES.get(sim.lower(), ("spice",))
+        for entry in entries:
             if entry.get("implementation", "").lower() == sim.lower():
                 return entry
+        for entry in entries:
+            if entry.get("language") in accepted:
+                return entry
+        return None
 
-        return spice_entries[0]  # Use first as default
+    _DC_OFFSET_VARIANTS = {"sin", "pulse"}
+
+    def _add_source(self, name, node_plus, node_minus, props, *, is_voltage):
+        """Add a voltage or current source, dispatching to structural InSpice
+        classes when ``props["tran"]`` is a tagged variant map.
+        """
+        dc = props.get("dc")
+        ac = props.get("ac")
+        tran = props.get("tran")
+
+        if isinstance(tran, dict) and tran.get("type"):
+            variant = tran["type"]
+            param_map = _TRAN_PARAM_MAP.get(variant, {})
+            kind = "voltage" if is_voltage else "current"
+            cls = _TRAN_SOURCE_CLASSES.get(variant, {}).get(kind)
+            if cls:
+                kwargs = {}
+                for tran_key, inspice_kwarg in param_map.items():
+                    val = _parse_spice_value(tran.get(tran_key))
+                    if val is not None:
+                        kwargs[inspice_kwarg] = val
+                if variant in self._DC_OFFSET_VARIANTS and dc is not None:
+                    kwargs["dc_offset"] = _parse_spice_value(dc) or 0
+                if variant in self._DC_OFFSET_VARIANTS and ac is not None:
+                    ac_val = _parse_spice_value(ac)
+                    if ac_val is not None:
+                        kwargs["ac_magnitude"] = ac_val
+                method = getattr(self, cls.__name__)
+                method(name, node_plus, node_minus, **kwargs)
+                return
+
+        fn = self.V if is_voltage else self.I
+        fn(name, node_plus, node_minus, dc, ac)
 
     def populate_from_nyancad(self, docs, models, corners=None, sim="NgSpice"):
         """Populate this netlist with elements from NyanCAD docs.
@@ -603,16 +751,10 @@ class NyanCADMixin:
             self.D(name, p("P"), p("N"), **props)
 
         elif device_type == "vsource":
-            dc = props.get("dc")
-            ac = props.get("ac")
-            tran = props.get("tran")
-            self.V(name, p("P"), p("N"), dc, ac, tran)
+            self._add_source(name, p("P"), p("N"), props, is_voltage=True)
 
         elif device_type == "isource":
-            dc = props.get("dc")
-            ac = props.get("ac")
-            tran = props.get("tran")
-            self.I(name, p("P"), p("N"), dc, ac, tran)
+            self._add_source(name, p("P"), p("N"), props, is_voltage=False)
 
         elif device_type in {"pmos", "nmos"}:
             bulk_node = p("B") if "B" in ports else self.gnd

--- a/python/nyancad/nyancad/netlist.py
+++ b/python/nyancad/nyancad/netlist.py
@@ -233,7 +233,6 @@ _TRAN_PARAM_MAP = {
 }
 
 
-
 def _eval_params(entry_params, device_props, sim="NgSpice"):
     """Substitute device props into SPICE param expressions.
 

--- a/python/nyancad/tests/conftest.py
+++ b/python/nyancad/tests/conftest.py
@@ -12,5 +12,10 @@ def spice_model_def():
             {"language": "verilog", "implementation": "Verilator"},
             {"language": "spice", "implementation": "NgSpice", "name": "nmos_3p3"},
             {"language": "spice", "implementation": "Xyce", "name": "nmos_xyce"},
+            {
+                "language": "spectre",
+                "implementation": "VACASK",
+                "name": "nmos_vacask",
+            },
         ],
     }

--- a/python/nyancad/tests/test_netlist.py
+++ b/python/nyancad/tests/test_netlist.py
@@ -12,6 +12,7 @@ from nyancad.netlist import (
     NyanCircuit,
     SchemId,
     _eval_params,
+    _parse_spice_value,
     _select_corner,
     bare_id,
     default_port_order,
@@ -219,6 +220,26 @@ class TestSelectModelEntry:
         entry = self._select(model_def, "NgSpice")
         # Even though sim doesn't match, it's the only SPICE entry — use it
         assert entry["implementation"] == "Xyce"
+
+    def test_vacask_selects_spectre_entry(self, spice_model_def):
+        entry = self._select(spice_model_def, "VACASK")
+        assert entry["name"] == "nmos_vacask"
+
+    def test_vacask_ignores_spice_entries(self):
+        model_def = {
+            "models": [
+                {"language": "spice", "implementation": "NgSpice", "name": "ng"},
+            ]
+        }
+        assert self._select(model_def, "VACASK") is None
+
+    def test_ngspice_ignores_spectre_entries(self):
+        model_def = {
+            "models": [
+                {"language": "spectre", "implementation": "VACASK", "name": "v"},
+            ]
+        }
+        assert self._select(model_def, "NgSpice") is None
 
 
 # ---------------------------------------------------------------------------
@@ -1146,3 +1167,167 @@ class TestKfNetlistFromNyancad:
 
         assert list(recnet) == ["top"]
         assert _kf_data(recnet["top"])["instances"]["top_S1"]["component"] == "straight"
+
+
+# ---------------------------------------------------------------------------
+# _parse_spice_value — SPICE engineering notation to float
+# ---------------------------------------------------------------------------
+
+
+class TestParseSpiceValue:
+    """_parse_spice_value converts SPICE engineering notation to Python floats."""
+
+    def test_plain_integer(self):
+        assert _parse_spice_value("100") == 100.0
+
+    def test_plain_float(self):
+        assert _parse_spice_value("3.14") == 3.14
+
+    def test_scientific_notation(self):
+        assert _parse_spice_value("1e3") == 1000.0
+
+    def test_kilo_suffix(self):
+        assert _parse_spice_value("1k") == 1e3
+
+    def test_nano_suffix(self):
+        assert _parse_spice_value("10n") == 1e-8
+
+    def test_meg_suffix(self):
+        assert _parse_spice_value("4.7Meg") == pytest.approx(4.7e6)
+
+    def test_micro_suffix(self):
+        assert _parse_spice_value("500u") == pytest.approx(500e-6)
+
+    def test_pico_suffix(self):
+        assert _parse_spice_value("10p") == pytest.approx(10e-12)
+
+    def test_femto_suffix(self):
+        assert _parse_spice_value("1f") == 1e-15
+
+    def test_none_returns_none(self):
+        assert _parse_spice_value(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_spice_value("") is None
+
+    def test_whitespace_returns_none(self):
+        assert _parse_spice_value("  ") is None
+
+    def test_numeric_passthrough(self):
+        assert _parse_spice_value(42) == 42.0
+        assert _parse_spice_value(3.14) == 3.14
+
+
+# ---------------------------------------------------------------------------
+# Structured source parameters — InSpice dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredSources:
+    """Structured transient source parameters dispatch to InSpice's typed
+    source classes instead of passing raw SPICE strings.
+    """
+
+    def _source_schem(self, device_type, props):
+        prefix = "V" if device_type == "vsource" else "I"
+        return {
+            "top": {
+                f"top:{prefix}1": {
+                    "_id": f"top:{prefix}1",
+                    "type": device_type,
+                    "name": f"{prefix}1",
+                    "nets": {"P": "inp", "N": "gnd"},
+                    "props": props,
+                }
+            },
+            "models": {},
+        }
+
+    def test_sin_voltage(self):
+        props = {
+            "dc": "0",
+            "tran": {"type": "sin", "offset": "0", "amplitude": "1", "frequency": "1k"},
+        }
+        spice = str(NyanCircuit("top", self._source_schem("vsource", props)))
+        assert "SIN(" in spice
+        assert "1000.0Hz" in spice
+
+    def test_sin_current(self):
+        props = {
+            "dc": "0",
+            "tran": {
+                "type": "sin",
+                "offset": "0",
+                "amplitude": "1m",
+                "frequency": "1k",
+            },
+        }
+        spice = str(NyanCircuit("top", self._source_schem("isource", props)))
+        assert "SIN(" in spice
+        assert "0.001A" in spice
+
+    def test_pulse_voltage(self):
+        props = {
+            "dc": "0",
+            "tran": {
+                "type": "pulse",
+                "initial": "0",
+                "pulsed": "5",
+                "width": "500u",
+                "period": "1m",
+            },
+        }
+        spice = str(NyanCircuit("top", self._source_schem("vsource", props)))
+        assert "PULSE(" in spice
+        assert "5.0V" in spice
+
+    def test_exp_voltage(self):
+        props = {
+            "dc": "0",
+            "tran": {
+                "type": "exp",
+                "initial": "0",
+                "pulsed": "5",
+                "rise-delay": "0",
+                "rise-tau": "1m",
+                "fall-delay": "2m",
+                "fall-tau": "1m",
+            },
+        }
+        spice = str(NyanCircuit("top", self._source_schem("vsource", props)))
+        assert "EXP(" in spice
+        assert "5.0V" in spice
+
+    def test_sffm_voltage(self):
+        props = {
+            "dc": "0",
+            "tran": {
+                "type": "sffm",
+                "offset": "0",
+                "amplitude": "1",
+                "carrier-freq": "1Meg",
+                "mod-index": "5",
+                "signal-freq": "10k",
+            },
+        }
+        spice = str(NyanCircuit("top", self._source_schem("vsource", props)))
+        assert "SFFM(" in spice
+        assert "1000000.0Hz" in spice
+
+    def test_dc_only_no_tran(self):
+        props = {"dc": "5", "ac": "1"}
+        spice = str(NyanCircuit("top", self._source_schem("vsource", props)))
+        assert "DC 5" in spice
+        assert "SIN(" not in spice
+        assert "PULSE(" not in spice
+
+    def test_dc_only_empty_tran_dict(self):
+        props = {"dc": "5", "tran": {}}
+        spice = str(NyanCircuit("top", self._source_schem("vsource", props)))
+        assert "DC 5" in spice
+        assert "SIN(" not in spice
+
+    def test_legacy_string_tran_ignored(self):
+        props = {"dc": "5", "tran": "SIN(0 1 1k)"}
+        spice = str(NyanCircuit("top", self._source_schem("vsource", props)))
+        assert "DC 5" in spice

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -107,6 +107,27 @@
        [:div.field-with-extra input extra-el]
        input)]))
 
+(defn- tagged-enum-editor
+  "Render a tagged union: a select for the discriminant, then the matching variant's children."
+  [{:keys [tag-key variants tooltip]} enum-cursor on-change wrap-leaf path]
+  (let [tag-val (get @enum-cursor (keyword tag-key))
+        variant (first (filter #(= (:value %) tag-val) variants))]
+    [:<>
+     [:label {:title tooltip} tag-key]
+     [:select {:value (or tag-val "")
+               :on-change #(let [v (.. % -target -value)
+                                  selected (first (filter (fn [vr] (= (:value vr) v)) variants))
+                                  defaults (into {} (map (fn [{:keys [name default]}]
+                                                           [(keyword name) (if (some? default) default "")]))
+                                                   (:children selected))]
+                             (reset! enum-cursor (if (seq v) (merge {(keyword tag-key) v} defaults) {}))
+                             (when on-change (on-change)))}
+      [:option {:value ""} "None"]
+      (for [{:keys [value label]} variants]
+        [:option {:key value :value value} label])]
+     (when variant
+       [recursive-editor (:children variant) enum-cursor on-change wrap-leaf path])]))
+
 (defn- list-editor
   "Render a list of maps: fieldset per item with add/remove, recurse per item."
   [{:keys [tooltip children type] :or {type :label}} list-cursor on-change wrap-leaf path]
@@ -139,11 +160,15 @@
   ([fields cursor on-change wrap-leaf path]
    [:<>
     (doall
-     (for [{:keys [name children] :as field} fields]
+     (for [{:keys [name children type] :as field} fields]
        (let [new-path (conj path (keyword name))]
          [:<> {:key name}
-          (if children
+          (cond
+            (= type :tagged-enum)
+            [tagged-enum-editor field (r/cursor cursor [(keyword name)]) on-change wrap-leaf new-path]
+            children
             [list-editor field (r/cursor cursor [(keyword name)]) on-change wrap-leaf new-path]
+            :else
             [leaf-editor field cursor on-change
              (when wrap-leaf (wrap-leaf new-path))])])))]))
 

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -789,6 +789,38 @@
     "amp" (circuit-sym-amplifier k v)
     (circuit-sym-box k v)))
 
+(def tran-field
+  {:name "tran" :tooltip "Transient waveform" :type :tagged-enum
+   :tag-key "type"
+   :variants
+   [{:value "sin" :label "Sinusoidal"
+     :children [{:name "offset" :tooltip "DC offset" :default "0"}
+                {:name "amplitude" :tooltip "Amplitude" :default "1"}
+                {:name "frequency" :tooltip "Frequency (Hz)" :default "1k"}
+                {:name "delay" :tooltip "Delay (s)" :default "0"}
+                {:name "damping" :tooltip "Damping factor (1/s)" :default "0"}]}
+    {:value "pulse" :label "Pulse"
+     :children [{:name "initial" :tooltip "Initial value" :default "0"}
+                {:name "pulsed" :tooltip "Pulsed value" :default "5"}
+                {:name "width" :tooltip "Pulse width (s)" :default "500u"}
+                {:name "period" :tooltip "Period (s)" :default "1m"}
+                {:name "delay" :tooltip "Delay (s)" :default "0"}
+                {:name "rise" :tooltip "Rise time (s)" :default "10n"}
+                {:name "fall" :tooltip "Fall time (s)" :default "10n"}]}
+    {:value "exp" :label "Exponential"
+     :children [{:name "initial" :tooltip "Initial value" :default "0"}
+                {:name "pulsed" :tooltip "Pulsed value" :default "5"}
+                {:name "rise-delay" :tooltip "Rise delay time (s)" :default "0"}
+                {:name "rise-tau" :tooltip "Rise time constant (s)"}
+                {:name "fall-delay" :tooltip "Fall delay time (s)"}
+                {:name "fall-tau" :tooltip "Fall time constant (s)"}]}
+    {:value "sffm" :label "Single-Freq FM"
+     :children [{:name "offset" :tooltip "Offset" :default "0"}
+                {:name "amplitude" :tooltip "Amplitude" :default "1"}
+                {:name "carrier-freq" :tooltip "Carrier frequency (Hz)" :default "1M"}
+                {:name "mod-index" :tooltip "Modulation index" :default "5"}
+                {:name "signal-freq" :tooltip "Signal frequency (Hz)" :default "10k"}]}]})
+
 (def models {"pmos" {::bg cm/active-bg
                      ::conn mosfet-shape
                      ::sym mosfet-sym
@@ -838,7 +870,7 @@
                         ::template "{self.name}: {self.props.dc}V"
                         ::props [{:name "dc" :tooltip "DC voltage" :spice "dc"}
                                  {:name "ac" :tooltip "AC voltage" :spice "ac"}
-                                 {:name "tran" :tooltip "Transient voltage" :spice "tran"}]}
+                                 tran-field]}
              "isource" {::bg cm/twoport-bg
                         ::conn cm/twoport-conn
                         ::sym isource-elements
@@ -846,7 +878,7 @@
                         ::template "{self.name}: {self.props.dc}I"
                         ::props [{:name "dc" :tooltip "DC current" :spice "dc"}
                                  {:name "ac" :tooltip "AC current" :spice "ac"}
-                                 {:name "tran" :tooltip "Transient current" :spice "tran"}]}
+                                 tran-field]}
              "diode" {::bg cm/twoport-bg
                       ::conn cm/twoport-conn
                       ::sym #'diode-sym


### PR DESCRIPTION
## Summary

- **Structured transient sources**: V/I sources now use a tagged-enum UI (sin, pulse, exp, sffm) with typed fields instead of a raw SPICE string. The fields dispatch to InSpice's structured classes (PulseVoltageSource, SinusoidalVoltageSource, etc.) for correct SPICE output.
- **VACASK/Spectre language support**: `_select_model_entry` now filters model entries by simulator-compatible language (ngspice/xyce → spice, vacask → spectre) instead of hardcoding spice-only.
- **SPICE engineering notation parser**: `_parse_spice_value` converts strings like `1k`, `10n`, `4.7Meg` to floats for the structured source kwargs.
- **Default value population**: `tagged-enum-editor` now populates children with `:default` values when switching variants (mirrors `list-editor` behavior), preventing crashes from InSpice classes with required positional args.

## Test plan

- [x] `TestParseSpiceValue` — 10 cases covering engineering notation, edge cases, passthrough
- [x] `TestStructuredSources` — 10 cases covering sin/pulse/exp/sffm for voltage and current, DC-only, empty tran dict, legacy string fallback
- [x] `TestSelectModelEntry` — VACASK selects spectre entries, ignores spice; NgSpice ignores spectre
- [x] shadow-cljs compiles with 0 warnings
- [ ] Manual test: place a voltage source, select Pulse from the tran dropdown, verify fields populate with defaults