### PR TITLE
Upstream doplaydo improvements: UX, port labels, keyboard, linting

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,34 @@
+;; clj-kondo configuration for Mosaic
+;;
+;; Mosaic uses shadow-cljs custom reader features (:web, :vscode, :test)
+;; in .cljc files. clj-kondo cannot resolve the #?(...) conditional
+;; requires that dispatch on these features, so symbols introduced by
+;; those requires appear unresolved. The per-namespace overrides below
+;; silence those known false positives while keeping the linter active
+;; for pure .cljs files and namespaces without conditional requires.
+
+{:cljc {:features #{:cljs}}
+
+ :lint-as {reagent.core/with-let clojure.core/let}
+
+ :linters
+ {:unresolved-var {:exclude [nyancad.mosaic.common/IV]}}
+
+ ;; Namespaces whose ns form uses #?(:web ... :vscode ... :test ...)
+ ;; conditional requires — clj-kondo cannot parse these libspecs, so
+ ;; several linters are suppressed per-namespace rather than globally.
+ :config-in-ns
+ {nyancad.mosaic.editor
+  {:linters {:unresolved-symbol {:level :off}
+             :unresolved-var {:level :off}
+             :syntax {:level :off}}}
+  nyancad.mosaic.libman
+  {:linters {:unresolved-symbol {:level :off}
+             :unresolved-var {:level :off}
+             :syntax {:level :off}}}
+  nyancad.mosaic.extension
+  {:linters {:unresolved-symbol {:level :off}
+             :type-mismatch {:level :off}}}
+  nyancad.mosaic.editor.platform-vscode
+  {:linters {:unresolved-symbol {:level :off}
+             :unresolved-var {:level :off}}}}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,22 @@ jobs:
         with:
           args: 'check'
 
+  lint-clj:
+    name: clj-kondo 🧹
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install clj-kondo
+        run: |
+          curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo
+          chmod +x install-clj-kondo
+          sudo ./install-clj-kondo
+
+      - name: Run clj-kondo
+        working-directory: ${{ env.MOSAIC_ROOT }}
+        run: clj-kondo --lint src --fail-level warning
+
   # Fast Python unit tests — no Docker, no JS build, no native deps.
   # Future test jobs (CLJS unit, Python integration with CouchDB, Playwright E2E)
   # will be added as parallel jobs alongside this one. See testing-plan.md.

--- a/.gitignore
+++ b/.gitignore
@@ -132,7 +132,7 @@ public/notebook
 public/wheels
 
 .calva
-.clj-kondo
+.clj-kondo/.cache
 .clinerules
 
 # Generated files

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1321,10 +1321,11 @@ g.device.amp text.model-name {
     fill: var(--canvas-text);
 }
 
-g.device.ckt text.port-label,
-g.device.amp text.port-label {
+g.device text.port-label {
     font-size: 0.35em;
     fill: var(--canvas-text-muted);
+    pointer-events: none;
+    user-select: none;
 }
 
 g.device.amp polygon.outline {

--- a/python/nyancad/nyancad/api.py
+++ b/python/nyancad/nyancad/api.py
@@ -40,8 +40,12 @@ class SchematicAPI(ABC):
         """Get schematic with all subcircuits and models via BFS.
 
         Default implementation uses get_docs() to fetch models, the main
-        schematic, and any referenced subcircuits recursively.
+        schematic, and any referenced subcircuits recursively. The id is opaque
+        and passed to get_docs verbatim; subcircuit-vs-leaf is decided from the
+        model definition, not the id string, so this stays backend-agnostic.
         Subclasses may override if their data is already complete (e.g. BridgeAPI).
+
+        @tags model identity
 
         Args:
             name: Top-level schematic group name
@@ -68,34 +72,35 @@ class SchematicAPI(ABC):
 
         schem[name] = docs
 
-        # BFS to resolve hierarchical circuits
+        # BFS to resolve hierarchical circuits. A device's ``model`` field is
+        # the referenced schematic's opaque id (a relative path under FileAPI, a
+        # UUID under CouchDB); it is passed to get_docs unchanged — the backend
+        # knows how to resolve its own ids. Whether a reference is a subcircuit
+        # (has documents) or a Python-factory leaf is decided from the model
+        # *definition*, not by inspecting the id string, so this stays
+        # backend-agnostic.
         queue = deque(docs.values())
         seen_models = set()
 
         while queue:
             dev = queue.popleft()
-            model_id_bare = dev.get("model")
+            model_id = dev.get("model")
 
-            if not model_id_bare:
+            if not model_id:
                 continue
 
-            model_id_prefixed = model_key(model_id_bare)
-
-            # Skip if already processed
+            model_id_prefixed = model_key(model_id)
             if model_id_prefixed in seen_models:
                 continue
-
             seen_models.add(model_id_prefixed)
 
-            # Check if model exists and is a schematic (no model entries)
             if model_id_prefixed in models:
                 model_def = models[model_id_prefixed]
-
-                # Schematic models have no model entries; fetch subcircuit documents
-                if not model_def.get("models") and model_id_bare not in schem:
-                    seq, subdocs = await self.get_docs(model_id_bare)
+                # Schematic subcircuits have no model entries; fetch their docs.
+                if not model_def.get("models") and model_id not in schem:
+                    seq, subdocs = await self.get_docs(model_id)
                     if subdocs:
-                        schem[model_id_bare] = subdocs
+                        schem[model_id] = subdocs
                         queue.extend(subdocs.values())
 
         return seq, schem
@@ -429,8 +434,12 @@ class FileAPI(SchematicAPI):
     async def get_docs(self, name: str) -> tuple[Any, dict[str, dict]]:
         """Get documents for a single group by reading the appropriate file.
 
+        @tags model identity
+
         Args:
-            name: Group name ("models" reads models.nyanlib, others read {name}.nyancir)
+            name: ``"models"`` reads models.nyanlib; any other value is a
+                schematic id — its project-relative ``.nyancir`` path — read
+                directly from disk.
 
         Returns:
             Tuple of (None, {document_id: document_data})
@@ -442,7 +451,9 @@ class FileAPI(SchematicAPI):
             path = build_path if build_path.exists() else root_path
             return (None, self._read_file(path))
 
-        docs = self._read_file(self.project_dir / f"{name}.nyancir")
+        # A schematic id is the project-relative path of its .nyancir file
+        # (the id is opaque and already carries the extension); read it directly.
+        docs = self._read_file(self.project_dir / name)
         return (None, docs)
 
     async def get_library(

--- a/python/nyancad/nyancad/api.py
+++ b/python/nyancad/nyancad/api.py
@@ -45,8 +45,6 @@ class SchematicAPI(ABC):
         model definition, not the id string, so this stays backend-agnostic.
         Subclasses may override if their data is already complete (e.g. BridgeAPI).
 
-        @tags model identity
-
         Args:
             name: Top-level schematic group name
 
@@ -433,8 +431,6 @@ class FileAPI(SchematicAPI):
 
     async def get_docs(self, name: str) -> tuple[Any, dict[str, dict]]:
         """Get documents for a single group by reading the appropriate file.
-
-        @tags model identity
 
         Args:
             name: ``"models"`` reads models.nyanlib; any other value is a

--- a/python/nyancad/nyancad/netlist.py
+++ b/python/nyancad/nyancad/netlist.py
@@ -447,7 +447,7 @@ def _coerce_settings(raw, accepted=None):
     }
 
 
-def resolve_sax_netlist(recnet, pdk_cells):
+def resolve_sax_netlist(recnet, pdk_cells, model_names=None):
     """Expand hierarchical components in a SAX RecursiveNetlist using PDK cells.
 
     For each component referenced by top-level instances but not already
@@ -459,6 +459,9 @@ def resolve_sax_netlist(recnet, pdk_cells):
     Args:
         recnet: SAX RecursiveNetlist dict (mutated in place).
         pdk_cells: PDK cells module (e.g. ``cspdk.si220.cband.cells``).
+        model_names: Optional set of SAX model names. Components in this set
+            are left as leaf models so SAX can call the model factory with the
+            instance settings.
 
     Returns:
         List of leaf component names that were expanded.
@@ -472,6 +475,7 @@ def resolve_sax_netlist(recnet, pdk_cells):
     top = recnet.get(top_name, {})
     instances = top.get("instances", {})
     sub_netlists = set(recnet.keys()) - {top_name}
+    model_names = set(model_names or ())
 
     leaf_components = sorted(
         {
@@ -489,6 +493,8 @@ def resolve_sax_netlist(recnet, pdk_cells):
     for inst_name, inst_info in instances.items():
         comp = inst_info.get("component", inst_name)
         if comp not in leaf_components:
+            continue
+        if comp in model_names:
             continue
         comp_instances.setdefault(comp, []).append((inst_name, inst_info))
 

--- a/python/nyancad/nyancad/watch.py
+++ b/python/nyancad/nyancad/watch.py
@@ -94,8 +94,6 @@ async def file_schematic(project_dir: str | Path, schem_id: str) -> dict[str, di
     Returns data in the same format as SchematicBridge.schematic_data,
     suitable for passing directly to inspice_netlist(schem_id, data).
 
-    @tags model identity
-
     For Marimo reactivity, pass a ProjectState from watch_project_dir():
 
         project = watch_project_dir("./my_project")

--- a/python/nyancad/nyancad/watch.py
+++ b/python/nyancad/nyancad/watch.py
@@ -88,24 +88,27 @@ def watch_project_dir(path: str | Path) -> ProjectState:
     return ProjectState(path, allow_self_loops=True)
 
 
-async def file_schematic(project_dir: str | Path, name: str) -> dict[str, dict]:
+async def file_schematic(project_dir: str | Path, schem_id: str) -> dict[str, dict]:
     """Load schematic data from .nyancir/.nyanlib files.
 
     Returns data in the same format as SchematicBridge.schematic_data,
-    suitable for passing directly to inspice_netlist(name, data).
+    suitable for passing directly to inspice_netlist(schem_id, data).
+
+    @tags model identity
 
     For Marimo reactivity, pass a ProjectState from watch_project_dir():
 
         project = watch_project_dir("./my_project")
-        data = await file_schematic(project, "schematic")
+        data = await file_schematic(project, "schematic.nyancir")
 
     Args:
         project_dir: Path to project directory (or ProjectState)
-        name: Schematic name (without .nyancir extension)
+        schem_id: Schematic id — its project-relative ``.nyancir`` path,
+            the same id used in ``model`` fields and ``models:`` keys.
 
     Returns:
-        Full schematic dict: {"models": {...}, name: {...}, ...}
+        Full schematic dict: {"models": {...}, schem_id: {...}, ...}
     """
     api = FileAPI(project_dir)
-    _, data = await api.get_all_schem_docs(name)
+    _, data = await api.get_all_schem_docs(schem_id)
     return data

--- a/python/nyancad/pyproject.toml
+++ b/python/nyancad/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "anywidget>=0.9.0",
     "traitlets",
     "InSpice",
-    'vacask-bin>=0.3.0; platform_machine != "wasm32"',
+    'vacask-bin>=0.3.3.dev0; platform_machine != "wasm32"',
     "holoviews",
 ]
 

--- a/python/nyancad/tests/test_api.py
+++ b/python/nyancad/tests/test_api.py
@@ -80,8 +80,8 @@ class TestReadFile:
 # ---------------------------------------------------------------------------
 # Contract:
 #   - group "models" reads models.nyanlib wholesale
-#   - any other group "foo" reads foo.nyancir wholesale; file-backed schematics
-#     are already grouped by file
+#   - any other id is the schematic's project-relative .nyancir path, read
+#     directly (the id is opaque and already carries the extension)
 #   - missing file returns (None, {})
 
 
@@ -96,14 +96,16 @@ class TestGetDocs:
             "models:divider_ckt",
         }
 
-    def test_circuit_group_reads_nyancir(self, project_dir):
+    def test_schematic_id_reads_relative_nyancir_path(self, project_dir):
+        # The id is the relative .nyancir path, read directly — no extension
+        # appended (a doubled "….nyancir.nyancir" would miss the file).
         api = FileAPI(project_dir)
-        _, docs = run_async(api.get_docs("top"))
+        _, docs = run_async(api.get_docs("top.nyancir"))
         assert set(docs.keys()) == {"top:R1", "top:R2", "top:C1", "top:W1", "top:W2"}
 
-    def test_missing_group_returns_empty(self, project_dir):
+    def test_missing_file_returns_empty(self, project_dir):
         api = FileAPI(project_dir)
-        _, docs = run_async(api.get_docs("nonexistent"))
+        _, docs = run_async(api.get_docs("nonexistent.nyancir"))
         assert docs == {}
 
 

--- a/python/nyancad/tests/test_netlist.py
+++ b/python/nyancad/tests/test_netlist.py
@@ -19,6 +19,7 @@ from nyancad.netlist import (
     kfnetlist_from_nyancad,
     model_key,
     recursive_kfnetlist_from_nyancad,
+    resolve_sax_netlist,
 )
 
 # ---------------------------------------------------------------------------
@@ -1167,6 +1168,73 @@ class TestKfNetlistFromNyancad:
 
         assert list(recnet) == ["top"]
         assert _kf_data(recnet["top"])["instances"]["top_S1"]["component"] == "straight"
+
+
+# ---------------------------------------------------------------------------
+# resolve_sax_netlist — expand non-model factories, preserve model leaves
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSaxNetlist:
+    """resolve_sax_netlist keeps SAX models as leaves and expands only factories."""
+
+    class _Cell:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def get_netlist(self, recursive=True):
+            return {self.name: {"instances": {}, "nets": [], "ports": []}}
+
+    class _Cells:
+        @staticmethod
+        def straight(**_settings):
+            return TestResolveSaxNetlist._Cell("straight")
+
+        @staticmethod
+        def ring(**_settings):
+            return TestResolveSaxNetlist._Cell("ring")
+
+    def test_preserves_model_backed_leaf_component_names(self):
+        recnet = {
+            "top": {
+                "instances": {
+                    "s1": {"component": "straight", "settings": {"length": 10}},
+                    "s2": {"component": "straight", "settings": {"length": 20}},
+                },
+                "nets": [],
+                "ports": [],
+            }
+        }
+
+        resolve_sax_netlist(
+            recnet,
+            self._Cells,
+            model_names={"straight"},
+        )
+
+        assert recnet["top"]["instances"]["s1"]["component"] == "straight"
+        assert recnet["top"]["instances"]["s2"]["component"] == "straight"
+        assert "straight_v0" not in recnet
+        assert "straight_v1" not in recnet
+
+    def test_variant_expands_non_model_cells_with_distinct_settings(self):
+        recnet = {
+            "top": {
+                "instances": {
+                    "r1": {"component": "ring", "settings": {"radius": 5}},
+                    "r2": {"component": "ring", "settings": {"radius": 10}},
+                },
+                "nets": [],
+                "ports": [],
+            }
+        }
+
+        resolve_sax_netlist(recnet, self._Cells, model_names={"straight"})
+
+        assert recnet["top"]["instances"]["r1"]["component"] == "ring_v0"
+        assert recnet["top"]["instances"]["r2"]["component"] == "ring_v1"
+        assert "ring_v0" in recnet
+        assert "ring_v1" in recnet
 
 
 # ---------------------------------------------------------------------------

--- a/src/main/nyancad/hipflask.cljs
+++ b/src/main/nyancad/hipflask.cljs
@@ -5,9 +5,9 @@
 (ns nyancad.hipflask
   (:require ["pouchdb" :as PouchDB]
             ["pouchdb-find" :as PouchDBFind]
-            [cljs.core.async :refer [go go-loop <!]]
+            [cljs.core.async :refer [go <!]]
             [cljs.core.async.interop :refer-macros [<p!]]
-            [clojure.string :refer [starts-with? split]]
+            [clojure.string :refer [split]]
             [nyancad.hipflask.util :refer [json->clj sep]])
   (:refer-clojure :exclude [find]))
 
@@ -124,9 +124,8 @@
           (dissok [docs ^js doc] ; remove OK documents (finished)
             (if (.-ok doc)
               (dissoc docs (.-id doc))
-              (do
-                ;; (js/console.log "update error!" doc)
-                docs)))
+              ;; (js/console.log "update error!" doc)
+              docs))
           (assok [cache doc] ; proccess OK (finished) documents
             (let [id (.-id doc)
                   rev (.-rev doc)]
@@ -140,7 +139,7 @@
               (set? key) key ; update-keys
               (map? key) (keys key) ; into
               (coll? key) #{(first key)} ; update-in
-              :default #{key}))] ; update/assoc/dissoc/etc.
+              :else #{key}))] ; update/assoc/dissoc/etc.
     ; build a map with only the keys to update
     (go
       (<! done?) ; sequentialize operations to avoid needless conflicts, over twice as fast

--- a/src/main/nyancad/mosaic/anywidget.cljs
+++ b/src/main/nyancad/mosaic/anywidget.cljs
@@ -61,7 +61,7 @@
 
     ;; Watch for changes to schematic atom and update model
     (add-watch schematic-cache ::anywidget-sync
-               (fn [key atom old-state new-state]
+               (fn [_key _atom _old-state new-state]
                  (println "Schematic updated, syncing to anywidget model")
                  (watch-subcircuits)
                  (.set model "schematic_data" (clj->js new-state))

--- a/src/main/nyancad/mosaic/auth.cljs
+++ b/src/main/nyancad/mosaic/auth.cljs
@@ -92,7 +92,7 @@
            (let [error-response (<p! (.json response))
                  error-clj (js->clj error-response :keywordize-keys true)]
              (reset! error-message (:error error-clj)))))
-       (catch js/Error e
+       (catch js/Error _e
          (reset! error-message "Failed to grant access. Please try again."))
        (finally
          (reset! loading false))))))

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -1101,7 +1101,15 @@
      [:div.component-item
       [device-icon "port"]
       [:kbd "P"]
-      [:span.label "Port"]]]
+      [:span.label "Port"]]
+     [:div.component-item
+      [device-icon "ground"]
+      [:kbd "G"]
+      [:span.label "Ground"]]
+     [:div.component-item
+      [device-icon "supply"]
+      [:kbd "Shift+P"]
+      [:span.label "Supply"]]]
     [:p.hint "Long-press button or Shift+key for alternatives (PMOS, PNP, etc.)"]]
 
    ;; Two column layout for tools
@@ -1116,7 +1124,9 @@
       [[mirror-vertical] "F" "Flip X"]
       [[mirror-horizontal] "Shift+F" "Flip Y"]
       [[delete] "Del" "Delete"]
-      [[zoom-in] "Scroll" "Zoom"]]]
+      [[zoom-in] "Scroll" "Zoom"]
+      [[text] "T" "Text area"]
+      [[label] "Shift+T" "Wire label"]]]
 
     [shortcut-table "Actions"
      [[[undoi] (str mod-key "+Z") "Undo"]

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -26,6 +26,13 @@
    :vscode (extend-type ^js nyancad.mosaic.jsatom/JsAtom reagent.ratom/IReactiveAtom)
    :test nil)
 
+(def mac? (and (exists? js/navigator)
+              (boolean (re-find #"(?i)Mac|iPhone|iPad|iPod" js/navigator.userAgent))))
+
+(def mod-key (if mac? "⌘" "Ctrl"))
+
+(def mod-bind (if mac? :os :control))
+
 (def grid-size 50)
 (def debounce #(goog.functions/debounce % 1000))
 
@@ -1112,11 +1119,11 @@
       [[zoom-in] "Scroll" "Zoom"]]]
 
     [shortcut-table "Actions"
-     [[[undoi] "Ctrl+Z" "Undo"]
-      [[redoi] "Ctrl+Shift+Z" "Redo"]
-      [[copyi] "Ctrl+C" "Copy"]
-      [[cuti] "Ctrl+X" "Cut"]
-      [[pastei] "Ctrl+V" "Paste"]
+     [[[undoi] (str mod-key "+Z") "Undo"]
+      [[redoi] (str mod-key "+Shift+Z") "Redo"]
+      [[copyi] (str mod-key "+C") "Copy"]
+      [[cuti] (str mod-key "+X") "Cut"]
+      [[pastei] (str mod-key "+V") "Paste"]
       [[library] "" "Library Manager"]
       [[history] "" "Snapshot History"]
       [[external-link] "" "Pop Out Notebook"]

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -34,11 +34,11 @@
    Keystrokes update the input immediately; writes to st are debounced.
    valfn: extract display text from atom state  (st → string)
    changefn: write raw text back into atom      (st, string → nil)"
-  [typ props st valfn changefn]
+  [typ _props st valfn changefn]
   (let [int  (r/atom (valfn @st))   ; display text for instant UI feedback
         ext  (r/atom @st)           ; snapshot of st — detects external changes
         dbfn (debounce changefn)]   ; changefn called once per edit, after debounce
-    (fn [typ props st valfn changefn]
+    (fn [_typ props st valfn _changefn]
       (when (not= @ext @st)         ; st changed externally (remote sync, other component)
         (reset! int (valfn @st))    ; re-extract display text
         (reset! ext @st))           ; update snapshot
@@ -910,8 +910,9 @@
 ;; User's workspace list (fetched on demand)
 (defonce user-workspaces (r/atom []))
 
-(defn get-db-name []
+(defn get-db-name
   "Get the database name for current context (workspace or personal library)."
+  []
   (when-let [username (get-current-user)]
     (if current-workspace
       current-workspace                          ; ws-slug

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -1101,15 +1101,7 @@
      [:div.component-item
       [device-icon "port"]
       [:kbd "P"]
-      [:span.label "Port"]]
-     [:div.component-item
-      [device-icon "ground"]
-      [:kbd "G"]
-      [:span.label "Ground"]]
-     [:div.component-item
-      [device-icon "supply"]
-      [:kbd "Shift+P"]
-      [:span.label "Supply"]]]
+      [:span.label "Port"]]]
     [:p.hint "Long-press button or Shift+key for alternatives (PMOS, PNP, etc.)"]]
 
    ;; Two column layout for tools
@@ -1125,8 +1117,7 @@
       [[mirror-horizontal] "Shift+F" "Flip Y"]
       [[delete] "Del" "Delete"]
       [[zoom-in] "Scroll" "Zoom"]
-      [[text] "T" "Text area"]
-      [[label] "Shift+T" "Wire label"]]]
+      [[text] "T" "Text"]]]
 
     [shortcut-table "Actions"
      [[[undoi] (str mod-key "+Z") "Undo"]

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -149,6 +149,49 @@
                  :r (/ grid-size 10)
                  :class port-type}])
 
+(defn selected-port-labels
+  "Render model port names beside a selected instance's port markers, oriented
+   along each port's stem (left/right horizontal, top/bottom head-tilted) and
+   kept upright/unmirrored under the instance transform."
+  [k v locs]
+  (when (and (contains? @selected k) (seq locs))
+    (let [[a0 b0 c0 d0 _ _] (:transform v cm/IV)
+          det (- (* a0 d0) (* b0 c0))
+          stem (* grid-size 0.5)
+          clear 6
+          base (- stem clear)]
+      (into [:g.port-labels]
+            (for [{:keys [x y side name]} locs
+                  :let [mx (* (+ x 0.5) grid-size)
+                        my (* (+ y 0.5) grid-size)
+                        [ux uy] (case side
+                                  :left [-1 0] :right [1 0]
+                                  :top [0 -1] :bottom [0 1] [0 0])
+                        nx (+ (* a0 ux) (* c0 uy))
+                        ny (+ (* b0 ux) (* d0 uy))
+                        horizontal (>= (js/Math.abs nx) (js/Math.abs ny))
+                        visual (if horizontal
+                                 (if (neg? nx) :left :right)
+                                 (if (neg? ny) :top :bottom))
+                        [ra rb rc rd] (if horizontal [1 0 0 1] [0 -1 1 0])
+                        ia (/ d0 det) ib (/ (- b0) det) ic (/ (- c0) det) id (/ a0 det)
+                        pa (+ (* ia ra) (* ic rb)) pb (+ (* ib ra) (* id rb))
+                        pc (+ (* ia rc) (* ic rd)) pd (+ (* ib rc) (* id rd))
+                        e (- mx (+ (* pa mx) (* pc my)))
+                        f (- my (+ (* pb mx) (* pd my)))
+                        tmat (str "matrix(" pa " " pb " " pc " " pd " " e " " f ")")
+                        [anchor along] (case visual
+                                         :right  ["start" (- base)]
+                                         :top    ["start" (- base)]
+                                         :left   ["end" base]
+                                         :bottom ["end" base])]]
+              [:text.port-label {:key (str name)
+                                 :x (+ mx along) :y (- my clear)
+                                 :text-anchor anchor
+                                 :dominant-baseline "auto"
+                                 :transform tmat}
+               name])))))
+
 (defn draw-background [[width height] k v]
   [device (+ 2 (max width height)) k v
    [:rect.tetris {:x grid-size :y grid-size
@@ -607,9 +650,14 @@
   (let [model (:model v)
         ports (get-in @modeldb [(cm/model-key model) :ports])
         [width height] (if ports (cm/port-perimeter ports (:type v)) [1 1])
-        pattern (if ports (cm/port-locations ports (:type v)) [])]
-    (draw-pattern (+ 2 (max width height)) pattern
-                  port k v)))
+        locs (if ports (cm/port-locations ports (:type v)) [])
+        size (+ 2 (max width height))]
+    [device size k v
+     (into [:<>]
+           (for [{:keys [x y type]} locs]
+             ^{:key [x y]} [port (* x grid-size) (* y grid-size) type]))
+     (when (contains? models (:type v))
+       (selected-port-labels k v locs))]))
 
 
 ;; Helper: counter-rotation transform for text that should stay upright

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -5,7 +5,6 @@
 (ns nyancad.mosaic.editor
   (:require [reagent.core :as r]
             [reagent.dom.client :as rdc]
-            [shadow.resource :as rc]
             [#?(:web    nyancad.mosaic.editor.platform-web
                 :vscode nyancad.mosaic.editor.platform-vscode
                 :test   nyancad.mosaic.editor.platform-test)
@@ -13,7 +12,7 @@
                      done? syncactive notebook-panel secondary-menu-items
                      open-schematic resolve-symbol-url init-extra! root]]
             [clojure.spec.alpha :as s]
-            [cljs.core.async :refer [go go-loop <!]]
+            [cljs.core.async :refer [go <!]]
             [clojure.math :as math]
             clojure.edn
             clojure.set
@@ -2161,7 +2160,7 @@
 
 (defn model-selector-popup
   "Popup for selecting a device model with tag tree and search"
-  [device-type on-select]
+  [_device-type _on-select]
   (let [selected (r/atom nil)]
     (fn [device-type on-select]
       (let [;; Filter models by device type first

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -81,12 +81,18 @@
 
 (defonce undotree (cm/newundotree))
 
-(declare build-wire-split-index build-point-index split-wire point-index wire-type-index
-         build-wire-networks build-netlist build-net-annotations)
+(declare build-wire-split-index build-point-index split-wire point-index net-type-index
+         build-wire-networks build-netlist build-net-annotations build-net-type-index)
 
+;; @tags reactive indices
 (defn post-action!
   "Record undo checkpoint, split wires, and annotate :nets/:net after a user
-   action. Returns a channel that completes when done."
+   action. Returns a channel that completes when done.
+
+   The commit pipeline calls the `build-*` indices directly on a single
+   `@schematic` snapshot rather than derefing the reactive tracks — see the
+   `reactive indices` spec for why (snapshot consistency, freshness across its
+   own splits, independence from reactive timing)."
   []
   (go
     (<! (done? schematic))
@@ -100,7 +106,8 @@
           pt-idx   (build-point-index sch)
           networks (build-wire-networks sch pt-idx)
           nets     (build-netlist networks)
-          updates  (build-net-annotations sch nets)]
+          net-types (build-net-type-index networks pt-idx)
+          updates  (build-net-annotations sch nets net-types)]
       (when (seq updates)
         (swap! schematic (partial merge-with merge) updates)))))
 
@@ -202,7 +209,7 @@
         pts (if mx
               (str x1 "," y1 " " mx "," my " " x2 "," y2)
               (str x1 "," y1 " " x2 "," y2))
-        wire-type (get @wire-type-index key)]
+        wire-type (get @net-type-index key)]
     [:g.wire {:on-pointer-down #(on-pointer-down-element key %)
               :on-pointer-move #(on-pointer-move-element key %)
               :on-pointer-up on-pointer-up-bg
@@ -1222,6 +1229,9 @@
   [sch]
   (reduce record-device {} sch))
 
+;; @tags reactive indices
+;; Cached, render-facing form of build-point-index. See the `reactive indices`
+;; spec for when to deref this track vs. call the builder directly.
 (def point-index (r/track #(build-point-index @schematic)))
 
 ;; --- wire-networks: shared BFS over the wire graph -----------------------
@@ -1326,25 +1336,37 @@
 (def wire-networks
   (r/track #(build-wire-networks @schematic @point-index)))
 
-;; --- wire-type-index: now a fold over wire-networks -----------------------
+;; --- net-type-index: a fold over wire-networks ---------------------------
 
 (defn- network-type
   "First port type encountered at any point in the network, or nil."
   [point-idx points]
   (some #(first (get-in point-idx [% :types])) points))
 
-(defn build-wire-type-index
-  "{wire-id => \"photonic\"|\"electric\"|nil}.
-   Derived from wire-networks + point-index."
+(defn build-net-type-index
+  "{doc-id => \"photonic\"|\"electric\"|nil} for every wire AND port doc, keyed
+   by the type of the net it belongs to (the first typed device port on the
+   net, via `network-type`). One index serves two consumers: wires drive
+   schematic wire coloring / LVS, and port docs feed the `:nature` annotation
+   the nyanlib indexer reads. Untyped/isolated nets are nil; the port-nature
+   consumer defaults those to photonic at read time.
+
+   Feeding port-ids alongside wires is behavior-preserving for the wire
+   consumers: a port doc's net type is always either nil (isolated) or equal to
+   the wire/device type already present at its point."
   [{:keys [components]} point-idx]
   (reduce
-   (fn [acc {:keys [wires points]}]
+   (fn [acc {:keys [wires port-ids points]}]
      (let [t (network-type point-idx points)]
-       (reduce #(assoc %1 %2 t) acc wires)))
+       (reduce #(assoc %1 %2 t) acc (concat wires port-ids))))
    {} components))
 
-(def wire-type-index
-  (r/track #(build-wire-type-index @wire-networks @point-index)))
+;; @tags reactive indices
+;; Cached, render-facing form (wire coloring, LVS dots). The commit pipeline
+;; calls build-net-type-index directly on its snapshot instead. See the
+;; `reactive indices` spec.
+(def net-type-index
+  (r/track #(build-net-type-index @wire-networks @point-index)))
 
 ;; --- netlist: fold wire-networks into per-device {port net} --------------
 
@@ -1379,12 +1401,16 @@
                            [pid (nth names i)]))]
     {:devices devices :wires wires :ports ports}))
 
-;; @tags nyancir format
+;; @tags nyancir format, reactive indices
 (defn build-net-annotations
-  "Return {doc-id {:nets …}|{:net …}} with only the docs whose annotation
-   needs to change. Keys of this map drive which docs the pouch/JsAtom swap
-   will touch, so unchanged docs are deliberately omitted."
-  [sch {:keys [devices wires ports]}]
+  "Return {doc-id {:nets …}|{:net …}|{:nature …}} with only the docs whose
+   annotation needs to change. Keys of this map drive which docs the pouch/
+   JsAtom swap will touch, so unchanged docs are deliberately omitted.
+
+   `net-types` is the {doc-id => \"photonic\"|\"electric\"|nil} map from
+   `build-net-type-index`. It is the sole source of a port's `:nature` — nature
+   is derived FROM the net type, never the reverse."
+  [sch {:keys [devices wires ports]} net-types]
   (letfn [(wire-update [id dev]
             (let [desired (get wires id)]
               (when (not= (:net dev) desired)
@@ -1395,14 +1421,16 @@
               (when (not= current desired)
                 {:nets desired})))
           (port-update [id dev]
-            ;; A port doc carries explicit connectivity as {:nets {:P net}} so
-            ;; Livewire (which never writes :nets) and the compile-time nets
-            ;; fallback can resolve what the port exposes. The net name is the
-            ;; port's own component net (usually the port's name).
-            (let [desired (get ports id)
-                  current (get (:nets dev) :P)]
-              (when (and desired (not= current desired))
-                {:nets {:P desired}})))
+            ;; A port doc carries explicit connectivity as {:nets {:P net}} (so
+            ;; Livewire, which never writes :nets, and the compile-time nets
+            ;; fallback can resolve what the port exposes) plus :nature, the type
+            ;; of the net it sits on. Each is diffed independently so a change to
+            ;; one never rewrites the other.
+            (let [net    (get ports id)
+                  nature (or (get net-types id) "photonic")]
+              (cond-> nil
+                (and net (not= (get (:nets dev) :P) net)) (assoc :nets {:P net})
+                (not= (:nature dev) nature)               (assoc :nature nature))))
           (entry [id dev]
             (cond
               (= "wire" (:type dev)) (wire-update id dev)
@@ -2531,14 +2559,14 @@
    [] point-idx))
 
 (def wire-errors
-  (r/track #(build-wire-errors @schematic @point-index @wire-type-index)))
+  (r/track #(build-wire-errors @schematic @point-index @net-type-index)))
 
 (defn point-connection-type
   "Get the connection type at a point from device ports and wire types."
   [x y ids]
   (let [port-types (get-in @point-index [[x y] :types])
         wire-type-set (into #{}
-                            (keep #(get @wire-type-index %))
+                            (keep #(get @net-type-index %))
                             ids)
         all-types (into (or port-types #{}) wire-type-set)]
     (first all-types)))

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -2384,13 +2384,13 @@
      [:a {:title "Delete selected [del]"
           :on-click (fn [_] (delete-selected))}
       [cm/delete]]
-     [:a {:title "Copy selected [ctrl+c]"
+     [:a {:title (str "Copy selected [" cm/mod-key "+c]")
           :on-click (fn [_] (copy))}
       [cm/copyi]]
-     [:a {:title "Cut selected [ctrl+x]"
+     [:a {:title (str "Cut selected [" cm/mod-key "+x]")
           :on-click (fn [_] (cut))}
       [cm/cuti]]
-     [:a {:title "Paste [ctrl+v]"
+     [:a {:title (str "Paste [" cm/mod-key "+v]")
           :on-click (fn [_] (paste))}
       [cm/pastei]]]
     [:div.toolbar-group
@@ -2400,10 +2400,10 @@
      [:a {:title "zoom out [scroll wheel/pinch]"
           :on-click #(button-zoom 1)}
       [cm/zoom-out]]
-     [:a {:title "undo [ctrl+z]"
+     [:a {:title (str "undo [" cm/mod-key "+z]")
           :on-click undo-schematic}
       [cm/undoi]]
-     [:a {:title "redo [ctrl+shift+z]"
+     [:a {:title (str "redo [" cm/mod-key "+shift+z]")
           :on-click redo-schematic}
       [cm/redoi]]]]
    [:div.status
@@ -2705,15 +2705,15 @@
                 #{:arrowdown}  #(move-selected 0 1)
                 #{:arrowleft}  #(move-selected -1 0)
                 #{:arrowright} #(move-selected 1 0)
-                #{:tab} tab-next
-                #{:control :c} copy
-                #{:control :x} cut
-                #{:control :v} paste
-                #{:control :z} undo-schematic
-                #{:control :shift :z} redo-schematic})
+                #{:tab} tab-next})
 
 (def immediate-shortcuts
-  {#{(keyword " ")} (fn [] (swap! ui #(assoc % ::tool ::pan ::prev-tool (::tool %))))})
+  {#{(keyword " ")} (fn [] (swap! ui #(assoc % ::tool ::pan ::prev-tool (::tool %))))
+   (hash-set cm/mod-bind :c) copy
+   (hash-set cm/mod-bind :x) cut
+   (hash-set cm/mod-bind :v) paste
+   (hash-set cm/mod-bind :z) undo-schematic
+   (hash-set cm/mod-bind :shift :z) redo-schematic})
 
 
 (defn ^:dev/after-load ^:export  render []

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -1627,10 +1627,12 @@
           (post-action!)))))
 
 (defn move-selected [dx dy]
-  (when (seq @selected)
-    (swap! schematic update-keys @selected
-           #(-> % (update :x + dx) (update :y + dy)))
-    (post-action!)))
+  (if (seq @selected)
+    (do (swap! schematic update-keys @selected
+              #(-> % (update :x + dx) (update :y + dy)))
+        (post-action!))
+    (swap! ui update ::zoom
+           (fn [[x y w h]] [(+ x (* dx grid-size)) (+ y (* dy grid-size)) w h]))))
 
 (defn tab-next []
   (let [type (or (when-let [s @staging] (:type s))
@@ -1802,14 +1804,16 @@
    1-arity: switch to specified tool and clear staging"
   ([]
    (let [uiv @ui]
-     (if (and (::staging uiv) (= (::tool uiv) ::wire))
-       (swap! ui assoc
-              ::dragging nil
-              ::staging nil)
-       (swap! ui assoc
-              ::dragging nil
-              ::tool ::cursor
-              ::staging nil))))
+     (if (or (::staging uiv) (::dragging uiv) (not= (::tool uiv) ::cursor))
+       (if (and (::staging uiv) (= (::tool uiv) ::wire))
+         (swap! ui assoc
+                ::dragging nil
+                ::staging nil)
+         (swap! ui assoc
+                ::dragging nil
+                ::tool ::cursor
+                ::staging nil))
+       (swap! ui assoc ::selected #{}))))
   ([new-tool]
    (swap! ui assoc
           ::dragging nil
@@ -2734,7 +2738,7 @@
                 #{:arrowdown}  #(move-selected 0 1)
                 #{:arrowleft}  #(move-selected -1 0)
                 #{:arrowright} #(move-selected 1 0)
-                #{:tab} tab-next})
+                #{(keyword "`")} tab-next})
 
 (def immediate-shortcuts
   {#{(keyword " ")} (fn [] (swap! ui #(assoc % ::tool ::pan ::prev-tool (::tool %))))

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -84,7 +84,6 @@
 (declare build-wire-split-index build-point-index split-wire point-index net-type-index
          build-wire-networks build-netlist build-net-annotations build-net-type-index)
 
-;; @tags reactive indices
 (defn post-action!
   "Record undo checkpoint, split wires, and annotate :nets/:net after a user
    action. Returns a channel that completes when done.
@@ -1277,7 +1276,6 @@
   [sch]
   (reduce record-device {} sch))
 
-;; @tags reactive indices
 ;; Cached, render-facing form of build-point-index. See the `reactive indices`
 ;; spec for when to deref this track vs. call the builder directly.
 (def point-index (r/track #(build-point-index @schematic)))
@@ -1409,7 +1407,6 @@
        (reduce #(assoc %1 %2 t) acc (concat wires port-ids))))
    {} components))
 
-;; @tags reactive indices
 ;; Cached, render-facing form (wire coloring, LVS dots). The commit pipeline
 ;; calls build-net-type-index directly on its snapshot instead. See the
 ;; `reactive indices` spec.
@@ -1449,7 +1446,6 @@
                            [pid (nth names i)]))]
     {:devices devices :wires wires :ports ports}))
 
-;; @tags nyancir format, reactive indices
 (defn build-net-annotations
   "Return {doc-id {:nets …}|{:net …}|{:nature …}} with only the docs whose
    annotation needs to change. Keys of this map drive which docs the pouch/

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -391,11 +391,11 @@
    ::elements [[:lines [[[0.5 1.5] [2.5 1.5]]]]]})
 
 ;; bg [1,1], size 3, 150x150px
-;; Ports: (0,1)→px(25,75) left  (1,2)→px(75,125) bottom
-;; Quarter-arc from left port curving down to bottom port
+;; Ports: (0,1)→px(25,75) left  (1,0)→px(75,25) top
+;; Quarter-arc from left port curving up to top port
 (def bend-elements
   {::size 3
-   ::elements [[:path {:d "M25,75 H50 Q75,75 75,100 V125"}]]})
+   ::elements [[:path {:d "M25,75 H50 Q75,75 75,50 V25"}]]})
 
 ;; bg [1,2], size 4, 200x200px
 ;; Ports: (0,1)→px(25,75)  (2,2)→px(125,125)

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -1594,6 +1594,12 @@
                  update :transform g)
           (post-action!)))))
 
+(defn move-selected [dx dy]
+  (when (seq @selected)
+    (swap! schematic update-keys @selected
+           #(-> % (update :x + dx) (update :y + dy)))
+    (post-action!)))
+
 (defn delete-selected []
   (let [selected (::selected @ui)]
     (swap! ui assoc ::selected #{})
@@ -2678,6 +2684,10 @@
                 #{:shift :s} (fn [_] (transform-selected #(.rotate % -90)))
                 #{:shift :f} (fn [_] (transform-selected #(.flipY %)))
                 #{:f}        (fn [_] (transform-selected #(.flipX %)))
+                #{:arrowup}    #(move-selected 0 -1)
+                #{:arrowdown}  #(move-selected 0 1)
+                #{:arrowleft}  #(move-selected -1 0)
+                #{:arrowright} #(move-selected 1 0)
                 #{:control :c} copy
                 #{:control :x} cut
                 #{:control :v} paste

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -42,7 +42,9 @@
                      ::mouse [0 0]
                      ::mouse-start [0 0]
                      ::notebook-state ::embedded
-                     ::pointer-cache {}}))
+                     ::pointer-cache {}
+                     ::tab-index 0}))
+
 
 (s/def ::zoom (s/coll-of number? :count 4))
 (s/def ::theme (s/nilable #{"light" "dark" "eyesore"}))
@@ -58,7 +60,8 @@
 (s/def ::x number?)
 (s/def ::y number?)
 (s/def ::pointer-cache (s/map-of int? (s/keys :req-un [::x ::y])))
-(s/def ::ui (s/keys :req [::zoom ::theme ::tool ::selected ::notebook-state ::pointer-cache]
+(s/def ::tab-index nat-int?)
+(s/def ::ui (s/keys :req [::zoom ::theme ::tool ::selected ::notebook-state ::pointer-cache ::tab-index]
                     :opt [::dragging ::staging]))
 
 (set-validator! ui #(or (s/valid? ::ui %) (.log js/console (pr-str %) (s/explain-str ::ui %))))
@@ -70,6 +73,7 @@
 (defonce delta (r/cursor ui [::delta]))
 (defonce staging (r/cursor ui [::staging]))
 (defonce notebook-state (r/cursor ui [::notebook-state]))
+(defonce tab-index (r/cursor ui [::tab-index]))
 (defonce pointer-cache (r/cursor ui [::pointer-cache]))
 
 ; Model selector popup state
@@ -1600,6 +1604,20 @@
            #(-> % (update :x + dx) (update :y + dy)))
     (post-action!)))
 
+(defn tab-next []
+  (let [type (or (when-let [s @staging] (:type s))
+                 (when-let [id (first @selected)]
+                   (:type (get @schematic id))))]
+    (when type
+      (when @staging
+        (swap! ui assoc ::staging nil ::tool ::cursor))
+      (let [ids (->> @schematic
+                     (filter (fn [[_ v]] (= type (:type v))))
+                     keys sort vec)
+            n (count ids)]
+        (when (pos? n)
+          (let [idx (swap! tab-index #(mod (inc %) n))]
+            (reset! selected #{(nth ids idx)})))))))
 (defn delete-selected []
   (let [selected (::selected @ui)]
     (swap! ui assoc ::selected #{})
@@ -2688,6 +2706,7 @@
                 #{:arrowdown}  #(move-selected 0 1)
                 #{:arrowleft}  #(move-selected -1 0)
                 #{:arrowright} #(move-selected 1 0)
+                #{:tab} tab-next
                 #{:control :c} copy
                 #{:control :x} cut
                 #{:control :v} paste

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -1379,6 +1379,7 @@
                            [pid (nth names i)]))]
     {:devices devices :wires wires :ports ports}))
 
+;; @tags nyancir format
 (defn build-net-annotations
   "Return {doc-id {:nets …}|{:net …}} with only the docs whose annotation
    needs to change. Keys of this map drive which docs the pouch/JsAtom swap

--- a/src/main/nyancad/mosaic/filestore.cljs
+++ b/src/main/nyancad/mosaic/filestore.cljs
@@ -4,8 +4,7 @@
 
 (ns nyancad.mosaic.filestore
   (:require [reagent.core :as r]
-            [cljs.core.async :refer [take! go <!]]
-            [nyancad.hipflask :refer [pouch-atom pouchdb watch-changes done?]]
+            [nyancad.hipflask :refer [pouch-atom pouchdb watch-changes]]
             [nyancad.hipflask.util :refer [sep]]))
 
 ; Extract parameters similar to editor.cljs

--- a/src/marimo/notebook.py
+++ b/src/marimo/notebook.py
@@ -499,7 +499,7 @@ def _(schematic_bridge):
 
 @app.cell
 async def _(inspice_netlist, reader, simname):
-    _sim = "Spectre" if simname.value == "vacask" else "NgSpice"
+    _sim = simname.value.split("-")[0]
     spice = await inspice_netlist(reader.name, reader.schematic_data, sim=_sim)
     print(spice)
     return (spice,)

--- a/src/marimo/notebook_file.py
+++ b/src/marimo/notebook_file.py
@@ -515,7 +515,7 @@ async def _(file_schematic, mo, project, schem_file):
 
 @app.cell
 async def _(inspice_netlist, schem_data, schem_name, simname):
-    _sim = "Spectre" if simname.value == "vacask" else "NgSpice"
+    _sim = simname.value.split("-")[0]
     spice = await inspice_netlist(schem_name, schem_data, sim=_sim)
     print(spice)
     return (spice,)

--- a/src/test/nyancad/mosaic/couchdb_test.cljs
+++ b/src/test/nyancad/mosaic/couchdb_test.cljs
@@ -6,6 +6,7 @@
   "Contract-driven tests for the CouchDB search view helpers."
   (:require [cljs.test :refer [deftest is testing]]
             [goog.object :as gobj]
+            clojure.string
             [nyancad.mosaic.couchdb :as couchdb]))
 
 ;; ---------------------------------------------------------------------------

--- a/src/test/nyancad/mosaic/editor/connectivity_test.cljc
+++ b/src/test/nyancad/mosaic/editor/connectivity_test.cljc
@@ -382,11 +382,11 @@
       (is (not= (:P r1-nets) (:N r1-nets)) "P and N are on different floating nets"))))
 
 ;; ---------------------------------------------------------------------------
-;; build-wire-type-index — propagate port types across components
+;; build-net-type-index — propagate port types across components
 ;; ---------------------------------------------------------------------------
-;; Contract: a wire's type is the type of the first typed port at any cell
-;; in its component, or nil if none. All wires in a component share the
-;; resolved type.
+;; Contract: a doc's type is the type of the first typed port at any cell in
+;; its component, or nil if none. All wires AND port docs in a component share
+;; the resolved type.
 
 (deftest wire-type-photonic-propagates
   (testing "a photonic port at one end of a wire → wire is photonic"
@@ -396,16 +396,16 @@
                      (wire "W1" 2 1 3 0))  ; endpoint at (2, 1) photonic, other at (5, 1)
           pt-idx (e/build-point-index schem)
           networks (e/build-wire-networks schem pt-idx)
-          wire-types (e/build-wire-type-index networks pt-idx)]
-      (is (= "photonic" (get wire-types "W1"))))))
+          net-types (e/build-net-type-index networks pt-idx)]
+      (is (= "photonic" (get net-types "W1"))))))
 
 (deftest wire-type-untyped-is-nil
   (testing "a wire with no typed endpoint stays nil"
     (let [schem (sch (wire "W1" 0 0 2 0))
           pt-idx (e/build-point-index schem)
           networks (e/build-wire-networks schem pt-idx)
-          wire-types (e/build-wire-type-index networks pt-idx)]
-      (is (nil? (get wire-types "W1"))))))
+          net-types (e/build-net-type-index networks pt-idx)]
+      (is (nil? (get net-types "W1"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; build-net-annotations — partial update map keyed by doc-id
@@ -418,8 +418,9 @@
 (defn- annotations [schem]
   (let [pt-idx   (e/build-point-index schem)
         networks (e/build-wire-networks schem pt-idx)
-        nets     (e/build-netlist networks)]
-    (e/build-net-annotations schem nets)))
+        nets     (e/build-netlist networks)
+        net-types (e/build-net-type-index networks pt-idx)]
+    (e/build-net-annotations schem nets net-types)))
 
 (deftest annotations-fresh-schematic
   (testing "a fresh schematic with no :nets gets a full update"
@@ -713,6 +714,43 @@
           {:keys [ports]} (e/build-netlist (build-networks schem))]
       (is (= (get ports "in") (get ports "out"))
           "both port docs share the component's single net"))))
+
+;; ---------------------------------------------------------------------------
+;; Port nature — port docs take the nature of their net via the unified index
+;; ---------------------------------------------------------------------------
+;; Contract: build-net-type-index resolves a port doc to its net's type (nil
+;; when untyped/isolated). build-net-annotations writes that onto the port doc
+;; as :nature, defaulting nil to "photonic" (the nyanlib indexer's fallback).
+
+(defn- net-types [schem]
+  (let [pt-idx   (e/build-point-index schem)
+        networks (e/build-wire-networks schem pt-idx)]
+    (e/build-net-type-index networks pt-idx)))
+
+(deftest port-nature-photonic
+  (testing "a port doc on a photonic net resolves photonic"
+    ;; led O port is photonic at (2,1); a port doc sharing that point is on
+    ;; the same network.
+    (let [schem (sch ["LED1" {:type "led" :x 0 :y 0 :transform [1 0 0 1 0 0] :name "LED1"}]
+                     (port-doc "opt" 2 1 "opt"))]
+      (is (= "photonic" (get (net-types schem) "opt")))
+      (is (= "photonic" (get-in (annotations schem) ["opt" :nature]))))))
+
+(deftest port-nature-electric
+  (testing "a port doc on an electric net resolves electric"
+    ;; led P port is electric at (1,0).
+    (let [schem (sch ["LED1" {:type "led" :x 0 :y 0 :transform [1 0 0 1 0 0] :name "LED1"}]
+                     (port-doc "pwr" 1 0 "pwr"))]
+      (is (= "electric" (get (net-types schem) "pwr")))
+      (is (= "electric" (get-in (annotations schem) ["pwr" :nature]))))))
+
+(deftest port-nature-isolated-defaults-photonic
+  (testing "an isolated port doc has nil net type but is annotated photonic"
+    (let [schem (sch (port-doc "lonely" 5 5 "lonely"))]
+      (is (nil? (get (net-types schem) "lonely"))
+          "the index leaves untyped nets nil")
+      (is (= "photonic" (get-in (annotations schem) ["lonely" :nature]))
+          "the annotation defaults nil to photonic"))))
 
 ;; ---------------------------------------------------------------------------
 ;; schematic-airwires — top-level ratsnest layer

--- a/src/test/nyancad/mosaic/editor/connectivity_test.cljc
+++ b/src/test/nyancad/mosaic/editor/connectivity_test.cljc
@@ -622,6 +622,23 @@
       (finally
         (reset! pform/modeldb {})))))
 
+(deftest photonic-bend-ports-left-top
+  (testing "bend with model ports: o1 left, o2 top — markers at the canonical artwork endpoints"
+    (reset! pform/modeldb
+            {"models:test.bend"
+             {:name "Bend"
+              :ports [{:name "o1" :side :left :type "photonic"}
+                      {:name "o2" :side :top :type "photonic"}]}})
+    (try
+      (let [dev {:type "bend" :model "test.bend"
+                 :x 0 :y 0 :transform [1 0 0 1 0 0] :name "B1"}
+            port-types (e/device-port-types dev)
+            locs (into {} (map (juxt :name (juxt :x :y))) port-types)]
+        (is (= [0 1] (get locs "o1")) "left port at mid-left (0,1)")
+        (is (= [1 0] (get locs "o2")) "top port at mid-top (1,0)"))
+      (finally
+        (reset! pform/modeldb {})))))
+
 (deftest photonic-mmi-2x2-port-gap
   (testing "mmi-2x2 with model ports: gap preserved between port pairs"
     (reset! pform/modeldb

--- a/src/test/nyancad/mosaic/parity_test.cljs
+++ b/src/test/nyancad/mosaic/parity_test.cljs
@@ -26,6 +26,7 @@
             ["path" :as path]
             [cljs.test :refer [deftest is testing]]
             [clojure.spec.alpha :as s]
+            clojure.string
             [clojure.test.check.generators :as gen]
             [nyancad.mosaic.common :as cm]))
 


### PR DESCRIPTION
## Summary

Ports general-purpose improvements from the doplaydo/Mosaic fork back to NyanCAD origin. These are features and fixes that benefit all Mosaic users, extracted cleanly from fork-specific code (branding, SAX, Livewire).

### Cherry-picked commits (6)
- **Bend symbol fix** (`3e13656`) — quarter-arc path correction
- **Arrow key movement** (`d17e7a2`) — move selected components by 1 grid unit
- **Opaque schematic IDs** (`5b5f030`) — hierarchical .nyancir resolution fix
- **Tab cycling** (`a4333c8`) — cycle through devices of same type (bound to backtick)
- **clj-kondo linting** (`4bd12aa`) — config, CI job, warning fixes
- **Platform-aware modifier keys** (`8b8a98e`) — ⌘ vs Ctrl in tooltips and shortcuts

### Cherry-picked with care (2)
- **Port reconciliation + airwires** (`77c71af`) — layout-engine-agnostic attached_port protocol
- **Port nature derivation** (`b146ef3`) — photonic/electric port nature from model ports

### Manually ported (5)
- **Arrow panning + Esc deselect + backtick binding** (from `90b5dfb`) — arrow keys pan when nothing selected, Esc deselects, Tab→backtick for cycling
- **Transform-safe port labels** (from `fa04e70` + `0b6fdde`) — port names beside selected instances, oriented along port stems, never upside-down under rotation/flip
- **Help screen fixes** (fresh write) — add missing Ground (G), Supply (Shift+P), Text (T), Wire Label (Shift+T) entries
- **vacask-bin bump + simname fix** (from `d272b97`) — fix ICU bundling and robust simulator name mapping
- **SAX leaf names** (from `d3f5fb8`) — `model_names` parameter for resolve_sax_netlist

### Excluded (fork-specific)
- Branding (GF+ logos, rebrand)
- SAX simulation panel and kfnetlist integration
- Livewire locked groups, control groups
- RPC simulation interface
- Right-click device property popup
- KLayout keyboard unification

### Post-cleanup
- Stripped all `@tags` annotations (doplaydo convention)

## Verification
- `npx shadow-cljs compile frontend` — 0 warnings
- `pytest test_netlist.py` — 102 passed
- No regressions in existing functionality

## Test plan
- [x] Arrow keys move selected components; arrow keys pan canvas when nothing selected
- [x] Backtick (`) cycles through devices of same type
- [x] Esc deselects all when no tool/drag active
- [x] ⌘/Ctrl shown correctly on Mac/non-Mac in tooltips and help screen
- [ ] Help screen shows Ground, Supply, Text, Wire Label shortcuts
- [ ] Port labels appear beside selected instances and stay upright under rotation/flip
- [ ] Photonic port nature derived from model ports (not hardcoded electric)