### PR TITLE
Pin marimo <0.23.10 to fix WASM notebook hang on ngSpice_Init

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,10 @@ jobs:
       - name: Install Python build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build marimo
+          # Keep marimo <0.23.10 so the WASM export bundles Pyodide 0.27.x; newer
+          # marimo ships Pyodide 314 (emscripten 5.0), which can't load the
+          # bundled libngspice.so and hangs the notebook on ngSpice_Init.
+          pip install build "marimo<0.23.10"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,7 +27,7 @@ This document contains instructions for developers and maintainers working on th
    ```bash
    python -m venv venv
    source venv/bin/activate  # On Windows: venv\Scripts\activate
-   pip install marimo build
+   pip install "marimo<0.23.10" build  # newer marimo ships Pyodide 314, which can't load the bundled libngspice.so
    ```
 
 ## Development Workflow

--- a/python/nyancad-server/pyproject.toml
+++ b/python/nyancad-server/pyproject.toml
@@ -20,7 +20,11 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "marimo>=0.19.0",
+    # Cap below 0.23.10: that release bumped the WASM runtime to Pyodide 314
+    # (emscripten 5.0), whose dynamic-linker no longer resolves the invoke_*
+    # SjLj trampolines that the bundled libngspice-44.2.so (emscripten 3.1.58)
+    # imports, hanging the notebook on ngSpice_Init. 0.23.9 pins Pyodide 0.27.7.
+    "marimo>=0.19.0,<0.23.10",
     "uvicorn[standard]>=0.23.0",
     "nyancad>=0.18.3",
     "httpx>=0.25.0",


### PR DESCRIPTION
## Problem

The WASM notebook hangs on `ngSpice_Init` during InSpice simulator creation (`Simulator.factory(...).simulation(spice)`). The symptom looked pthread-related.

## Investigation

I drove Pyodide in Node.js against the bundled `public/wasm-libs/libngspice-44.2.zip` across a matrix of Pyodide and InSpice versions (load Pyodide → micropip-install InSpice → write the `.so` to `/usr/lib` → `NgSpiceShared.new_instance()` + a real `.op` simulation), run under an external timeout to catch hangs.

**Pyodide sweep (InSpice 1.6.3.3):**

| Pyodide | emscripten / abi | Python | Result |
|---------|------------------|--------|--------|
| 0.26.4 – 0.27.7 | 3.1.58 / 2024_0 | 3.12 | ✅ init + op sim succeed |
| 0.28.3 | 4.0.9 / 2025_0 | 3.13 | ❌ `cannot resolve symbol invoke_iii` |
| 0.29.4 | 4.0.9 / 2025_0 | 3.13 | ❌ same |
| 314.0.0 / 314.0.1 | 5.0.3 / 2026_0 | 3.14 | ❌ same ← what the live site runs |

**InSpice:** only `1.6.3.3` works (earlier versions lack the `on_web` platform branch and crash on emscripten). The notebook already installs latest, so InSpice is not the lever.

**marimo → Pyodide** (pin lives in `marimo/_pyodide/pyodide_constraints.py`):
- marimo ≤ 0.23.9 → Pyodide 0.27.x → works
- marimo 0.23.10 / 0.23.11 → Pyodide 314.0.0 → broken (live site is on 0.23.11)

## Root cause

`libngspice-44.2.so` is built for the emscripten 3.1.58 ABI (Pyodide 0.27.x). It uses WASM setjmp/longjmp (`__wasm_setjmp`, `emscripten_longjmp`) and imports the `invoke_*` function-pointer trampolines. emscripten 4.0 (Pyodide 0.28) changed how those trampolines are provided to dynamically-loaded side modules, so `ffi.dlopen("libngspice.so")` can no longer resolve `invoke_iii`. In Node this is a hard error; in the browser the same dlopen failure inside the simulation cell surfaces as a cell that never finishes — the reported "hang on ngSpice_Init". It's an EH/SjLj toolchain ABI mismatch, **not** the pthread/`bg_run` path (that code is never reached).

The regression entered because `marimo` was unbounded (`>=0.19.0`), silently resolving to 0.23.11.

## Changes

- `python/nyancad-server/pyproject.toml`: cap `marimo>=0.19.0,<0.23.10` (resolves to 0.23.9 → Pyodide 0.27.7).
- `.github/workflows/main.yml`: pin the WASM export step's `pip install ... "marimo<0.23.10"` — the unpinned install there is what actually generates the broken bundle.
- `DEVELOPMENT.md`: match the local install instruction.

## Alternative (not done here)

Rebuild `libngspice` with an emscripten toolchain matching a newer Pyodide (4.0.x / 5.0.x) if staying on current marimo is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012uTmNKizDpDJjmAjZa67Jf)_