### PR TITLE
Fix ground/supply placement colliding on a single shared document id

### DIFF
--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -1649,7 +1649,12 @@
 
 (defn commit-staged [dev]
   (let [named (update dev :name (fnil identity (make-name (:type dev))))
-        id (str group sep (:name named))
+        ;; Port devices (ground, supply, labels) keep a fixed/constant display
+        ;; :name, so it can't double as a unique id the way "R1", "C1", etc.
+        ;; do for other device types. Give ports their own numbered id instead,
+        ;; matching the scheme paste already uses for pasted port devices.
+        id-name (if (= "port" (:type named)) (make-name "port") (:name named))
+        id (str group sep id-name)
         model-def (when (:model named)
                     (get @modeldb (cm/model-key (:model named))))
         defaults (cm/model-prop-defaults model-def)


### PR DESCRIPTION
Ground and supply ports set a fixed display :name ("GND"/"VDD") so
they read as the same net without needing a wire. But commit-staged
derived the CouchDB doc id directly from :name, so every ground placed
in a schematic collided on the same id ("port:GND"), overwriting the
previous one instead of adding a new instance.

Collaborative Work Statement:
- Reported by Pepijn: placing a ground behaved like a singleton because
  the id wasn't unique
- Claude traced commit-staged (id = group+sep+name) and found paste already
  solves this for copy/paste of ports: it draws the id from make-names by
  type while keeping the pasted device's original display name. Applied the
  same split (numbered id, constant name) to the initial placement path in
  commit-staged so it's no longer special-cased just for paste
- Verified via full cljs test suite (161 tests, 425 assertions, all passing)
  and a clean shadow-cljs frontend compile

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>