### PR TITLE
Upstream from doplaydo: zoom-to-fit + kfnetlist array-instance fix

### DIFF
--- a/python/nyancad/nyancad/netlist.py
+++ b/python/nyancad/nyancad/netlist.py
@@ -280,7 +280,7 @@ def kf_component_name(dev_id, dev, models):
     return model["name"]
 
 
-def invert_kf_nets(components, port_devices):
+def invert_kf_nets(components, port_devices, instance_ids=None):
     """Build ``{net_name: {"inst": [...], "ports": [...]}}`` from Mosaic nets.
 
     Port markers resolve via the same precedence as the converter: a
@@ -312,7 +312,12 @@ def invert_kf_nets(components, port_devices):
                 # Synthesize a net (keyed by the port name) joining the top
                 # port with its attached instance port.
                 bucket = out.setdefault(port_name_str, {"inst": [], "ports": []})
-                member = (_safe_ident(str(cid)), str(pn))
+                member = (
+                    instance_ids.get(str(cid), _safe_ident(str(cid)))
+                    if instance_ids
+                    else _safe_ident(str(cid)),
+                    str(pn),
+                )
                 if member not in bucket["inst"]:
                     bucket["inst"].append(member)
                 if port_name_str not in bucket["ports"]:
@@ -335,6 +340,69 @@ def _safe_ident(name):
     return re.sub(r"[^A-Za-z0-9_]", "_", name)
 
 
+def _dedupe_instance_ident(candidate, used):
+    base = candidate or "inst"
+    unique = base
+    suffix = 2
+    while unique in used:
+        unique = f"{base}_{suffix}"
+        suffix += 1
+    used.add(unique)
+    return unique
+
+
+def _kf_instance_id_map(docs):
+    """Choose stable kfnetlist instance IDs for Mosaic device docs.
+
+    Prefer the user-visible ``name`` when it is unique and already a valid
+    identifier so schematic netlists line up with layout extraction names.
+    Fall back to a sanitized document key and de-duplicate collisions.
+    """
+    components = [
+        (str(dev_id), dev)
+        for dev_id, dev in docs.items()
+        if dev.get("type") not in STRUCTURAL_TYPES
+    ]
+
+    valid_name_counts = {}
+    for _dev_id, dev in components:
+        name = dev.get("name")
+        if isinstance(name, str) and VALID_IDENT_RE.fullmatch(name):
+            valid_name_counts[name] = valid_name_counts.get(name, 0) + 1
+
+    used = set()
+    instance_ids = {}
+
+    for dev_id, dev in components:
+        name = dev.get("name")
+        if not (
+            isinstance(name, str)
+            and VALID_IDENT_RE.fullmatch(name)
+            and valid_name_counts.get(name) == 1
+            and not VALID_IDENT_RE.fullmatch(dev_id)
+        ):
+            continue
+        chosen = _dedupe_instance_ident(name, used)
+        instance_ids[dev_id] = chosen
+        raw_id = dev.get("_id")
+        if raw_id:
+            instance_ids[str(raw_id)] = chosen
+        instance_ids[_safe_ident(dev_id)] = chosen
+
+    for dev_id, dev in components:
+        if dev_id in instance_ids:
+            continue
+        fallback = _safe_ident(dev_id)
+        chosen = _dedupe_instance_ident(fallback, used)
+        instance_ids[dev_id] = chosen
+        raw_id = dev.get("_id")
+        if raw_id:
+            instance_ids[str(raw_id)] = chosen
+        instance_ids[fallback] = chosen
+
+    return instance_ids
+
+
 def kfnetlist_from_nyancad(name, schem, *, kcl="PDK"):
     """Build a ``kfnetlist.Netlist`` directly from Mosaic ``nets``.
 
@@ -345,6 +413,7 @@ def kfnetlist_from_nyancad(name, schem, *, kcl="PDK"):
 
     docs = schem.get(name, {})
     models = schem.get("models", {})
+    instance_ids = _kf_instance_id_map(docs)
 
     components = []
     port_devices = {}
@@ -352,7 +421,7 @@ def kfnetlist_from_nyancad(name, schem, *, kcl="PDK"):
         if dev.get("type") == "port":
             port_devices[str(dev.get("name") or dev_id)] = dev
         elif dev.get("type") not in STRUCTURAL_TYPES:
-            components.append((_safe_ident(dev_id), dev))
+            components.append((instance_ids[str(dev_id)], dev))
 
     netlist = Netlist()
     for dev_id, dev in components:
@@ -368,7 +437,7 @@ def kfnetlist_from_nyancad(name, schem, *, kcl="PDK"):
     for port_name in sorted(port_devices):
         top_ports[port_name] = netlist.create_port(str(port_name))
 
-    net_map = invert_kf_nets(components, port_devices)
+    net_map = invert_kf_nets(components, port_devices, instance_ids=instance_ids)
     for net_name in sorted(net_map):
         members = [
             *(top_ports[port] for port in net_map[net_name]["ports"]),

--- a/python/nyancad/tests/test_netlist.py
+++ b/python/nyancad/tests/test_netlist.py
@@ -1033,6 +1033,34 @@ class TestKfNetlistFromNyancad:
             {"instance": "top_S1", "port": "o1"},
         ] in data["nets"]
 
+    def test_prefers_unique_logical_name_over_prefixed_doc_key(self):
+        schem = {
+            "top": {
+                "top:X7": {
+                    "_id": "top:X7",
+                    "type": "mmi2x2",
+                    "name": "X7",
+                    "model": "mmi2x2",
+                    "nets": {"o1": "n_in", "o2": "n_out"},
+                },
+                "top:IN": {
+                    "type": "port",
+                    "name": "in",
+                    "attached_port": {"component_id": "top:X7", "port_name": "o1"},
+                },
+            },
+            "models": {
+                "models:mmi2x2": {"name": "mmi2x2", "ports": []},
+            },
+        }
+
+        netlist = kfnetlist_from_nyancad("top", schem)
+        data = _kf_data(netlist)
+
+        assert "X7" in data["instances"]
+        assert "top_X7" not in data["instances"]
+        assert [{"name": "in"}, {"instance": "X7", "port": "o1"}] in data["nets"]
+
     def test_uses_model_name_without_needing_layout(self):
         schem = {
             "top": {

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -617,6 +617,7 @@
 ; icons
 (def zoom-in (r/adapt-react-class icons/ZoomIn))
 (def zoom-out (r/adapt-react-class icons/ZoomOut))
+(def zoom-fit (r/adapt-react-class icons/ArrowsFullscreen))
 (def redoi (r/adapt-react-class icons/Arrow90degRight))
 (def undoi (r/adapt-react-class icons/Arrow90degLeft))
 (def rotatecw (r/adapt-react-class icons/ArrowClockwise))
@@ -1117,7 +1118,8 @@
       [[mirror-horizontal] "Shift+F" "Flip Y"]
       [[delete] "Del" "Delete"]
       [[zoom-in] "Scroll" "Zoom"]
-      [[text] "T" "Text"]]]
+      [[text] "T" "Text"]
+      [[zoom-fit] "Home" "Zoom to fit"]]]
 
     [shortcut-table "Actions"
      [[[undoi] (str mod-key "+Z") "Undo"]

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -1647,6 +1647,35 @@
                     (+ x (/ w 2))
                     (+ y (/ h 2)))))
 
+;; @tags mosaic viewport zoom
+(defn fit-viewbox
+  [bx by bw bh container-w container-h]
+  (let [pad 0.1
+        pw (* bw pad) ph (* bh pad)
+        cx (- bx pw) cy (- by ph)
+        cw (+ bw (* 2 pw)) ch (+ bh (* 2 ph))
+        cw (max cw grid-size) ch (max ch grid-size)
+        content-ar (/ cw ch)
+        container-ar (/ container-w container-h)]
+    (if (> container-ar content-ar)
+      (let [new-w (* ch container-ar)
+            dx (/ (- new-w cw) 2)]
+        [(- cx dx) cy new-w ch])
+      (let [new-h (/ cw container-ar)
+            dy (/ (- new-h ch) 2)]
+        [cx (- cy dy) cw new-h]))))
+
+;; @tags mosaic viewport zoom
+(defn zoom-to-fit []
+  (when-let [^js svg (js/document.querySelector ".mosaic-canvas")]
+    (when-let [^js el (.querySelector svg ".schematic-content")]
+      (let [bbox (.getBBox el)
+            bw (.-width bbox) bh (.-height bbox)]
+        (when (and (pos? bw) (pos? bh))
+          (let [vb (fit-viewbox (.-x bbox) (.-y bbox) bw bh
+                                (.-clientWidth svg) (.-clientHeight svg))]
+            (reset! ui (assoc @ui ::zoom vb))))))))
+
 (defn commit-staged [dev]
   (let [named (update dev :name (fnil identity (make-name (:type dev))))
         ;; Port devices (ground, supply, labels) keep a fixed/constant display
@@ -2482,6 +2511,9 @@
      [:a {:title "zoom out [scroll wheel/pinch]"
           :on-click #(button-zoom 1)}
       [cm/zoom-out]]
+     [:a {:title "zoom to fit [Home]"
+          :on-click #(zoom-to-fit)}
+      [cm/zoom-fit]]
      [:a {:title (str "undo [" cm/mod-key "+z]")
           :on-click undo-schematic}
       [cm/undoi]]
@@ -2748,9 +2780,10 @@
               :y (* -500 grid-size)
               :width (* 1000 grid-size)
               :height (* 1000 grid-size)}]
-      [schematic-elements @schematic]
-      [schematic-airwires]
-      [schematic-dots]
+      [:g.schematic-content
+       [schematic-elements @schematic]
+       [schematic-airwires]
+       [schematic-dots]]
       [tool-elements]]]
     [notebook-panel notebook-state]]
    [cm/contextmenu]
@@ -2787,7 +2820,8 @@
                 #{:arrowdown}  #(move-selected 0 1)
                 #{:arrowleft}  #(move-selected -1 0)
                 #{:arrowright} #(move-selected 1 0)
-                #{(keyword "`")} tab-next})
+                #{(keyword "`")} tab-next
+                #{:home} zoom-to-fit})
 
 (def immediate-shortcuts
   {#{(keyword " ")} (fn [] (swap! ui #(assoc % ::tool ::pan ::prev-tool (::tool %))))


### PR DESCRIPTION
Upstreams two fixes from the doplaydo fork into origin (round 2 of the [#204](https://github.com/NyanCAD/Mosaic/issues/204) sync, doplaydo → origin). Unlike the origin→doplaydo direction, this is a **selective cherry-pick** — doplaydo carries fork-specific GF+/Livewire/SAX/LVS code that must not enter origin.

## 1. Zoom-to-fit (`53690e1`)

Adds a zoom-to-fit toolbar button (ArrowsFullscreen icon) + **Home** shortcut that frames all schematic content with 10% padding and correct aspect ratio.

Squashes doplaydo `a53b267` (the feature — previously **deferred** in #204 as broken) with `73ddaf5` (the aspect-ratio/viewport-spec fix), so origin gets only the working result:
- `zoom-to-fit` queries a new `<g.schematic-content>` wrapper (excludes the grid rect from `getBBox`) and uses the SVG's own client dimensions.
- `fit-viewbox` expands the content bbox to the container aspect ratio (no letterboxing).

Conflicts resolved to origin conventions: Home added to the keyup `shortcuts` map (origin keeps copy/cut/paste/undo/redo in `immediate-shortcuts`); help-screen entry slotted into origin's table; dropped doplaydo's `@tags`-docstring migration hunk (origin already stripped `@tags`, and its `selected-port-labels` lives elsewhere — avoids duplication).

## 2. kfnetlist array-instance fix (`2714290`)

The Mosaic-subrepo portion of doplaydo `59327cd` (GF+ LVS PR #3090) that fixes origin's **existing** `kfnetlist` path:
- `invert_kf_nets` gains an optional `instance_ids` map; adds `_dedupe_instance_ident` / `_kf_instance_id_map`, threaded through `kfnetlist_from_nyancad`, fixing invalid netlists from instance renaming vs array instances.
- Adds `test_netlist.py` coverage. (The Rust/Elvis LVS-engine work from #3090 lives outside the subrepo and is GF+-specific — not included.)

## Verification

- `npx shadow-cljs compile frontend` → build completed, **0 warnings** (`icons/ArrowsFullscreen` resolves; `.mosaic-canvas` present on origin).
- `python -m py_compile` clean; new helpers + test present. The full `pytest tests/test_netlist.py` needs InSpice (CI) — please confirm green in CI.
- Recommend a quick interactive check: add devices, press **Home** / click the button → content framed with padding & correct aspect ratio.

Deferred to a later PR: `c53a9d9` (Ctrl-drag, currently trialed in doplaydo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)