### PR TITLE
Test jsatom edit protocol against real VSCode document model; fix false-value corruption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
       "devDependencies": {
         "@vscode/vsce": "^3.9.2",
         "pouchdb-adapter-memory": "^9.0.0",
-        "shadow-cljs": "^3.4.11"
+        "shadow-cljs": "^3.4.11",
+        "vscode-languageserver-textdocument": "^1.0.12"
       }
     },
     "node_modules/@azu/format-text": {
@@ -4780,6 +4781,13 @@
       "funding": {
         "url": "https://bevry.me/fund"
       }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vuvuzela": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "devDependencies": {
     "@vscode/vsce": "^3.9.2",
     "pouchdb-adapter-memory": "^9.0.0",
-    "shadow-cljs": "^3.4.11"
+    "shadow-cljs": "^3.4.11",
+    "vscode-languageserver-textdocument": "^1.0.12"
   },
   "dependencies": {
     "bootstrap-icons": "^1.11.2",

--- a/src/main/nyancad/mosaic/common.cljc
+++ b/src/main/nyancad/mosaic/common.cljc
@@ -23,7 +23,7 @@
 ;; platform: PAtom (PouchDB-backed) for the web app, JsAtom (jsonc-backed)
 ;; for the VSCode webview. The :test build runs under Node without either.
 #?(:web (extend-type ^js nyancad.hipflask/PAtom reagent.ratom/IReactiveAtom)
-   :vscode (extend-type ^js nyancad.mosaic.jsatom/JsAtom reagent.ratom/IReactiveAtom)
+   :vscode (extend-type ^js nyancad.mosaic.jsatom.protocol/JsAtom reagent.ratom/IReactiveAtom)
    :test nil)
 
 (def mac? (and (exists? js/navigator)

--- a/src/main/nyancad/mosaic/editor/platform_vscode.cljc
+++ b/src/main/nyancad/mosaic/editor/platform_vscode.cljc
@@ -3,7 +3,7 @@
 ; SPDX-License-Identifier: MPL-2.0
 
 (ns nyancad.mosaic.editor.platform-vscode
-  (:require [nyancad.mosaic.jsatom :as jsatom :refer [json-atom vscode send-request!]]
+  (:require [nyancad.mosaic.jsatom :as jsatom :refer [json-atom vscode send-request! injected-version]]
             [nyancad.mosaic.common :as cm]
             [reagent.core :as r]
             [reagent.dom.client :as rdc]
@@ -15,14 +15,6 @@
 (def done? jsatom/done?)
 
 ;; --- State ---
-
-(defn- injected-version
-  "Read a host document version injected into a hidden input, defaulting to 1
-   when absent or unparseable so the self-echo guard degrades to its old
-   behaviour rather than breaking."
-  [id]
-  (let [v (some-> (js/document.getElementById id) .-value (js/parseInt 10))]
-    (if (or (nil? v) (js/isNaN v)) 1 v)))
 
 (def group (.-value (js/document.getElementById "group")))
 (defonce schematic (json-atom "schematic"

--- a/src/main/nyancad/mosaic/editor/platform_vscode.cljc
+++ b/src/main/nyancad/mosaic/editor/platform_vscode.cljc
@@ -16,16 +16,26 @@
 
 ;; --- State ---
 
+(defn- injected-version
+  "Read a host document version injected into a hidden input, defaulting to 1
+   when absent or unparseable so the self-echo guard degrades to its old
+   behaviour rather than breaking."
+  [id]
+  (let [v (some-> (js/document.getElementById id) .-value (js/parseInt 10))]
+    (if (or (nil? v) (js/isNaN v)) 1 v)))
+
 (def group (.-value (js/document.getElementById "group")))
 (defonce schematic (json-atom "schematic"
                     (js/decodeURIComponent (.-value (js/document.getElementById "document")))
-                    (r/atom {})))
+                    (r/atom {})
+                    (injected-version "document-version")))
 (set-validator! schematic
                 #(or (s/valid? :nyancad.mosaic.common/schematic %) (.log js/console (pr-str %) (s/explain-str :nyancad.mosaic.common/schematic %))))
 ;; Secondary modeldb atom — initialized from models.nyanlib injected by extension
 (defonce modeldb (json-atom "models"
                    (js/decodeURIComponent (.-value (js/document.getElementById "models")))
-                   (r/atom {})))
+                   (r/atom {})
+                   (injected-version "models-version")))
 (defonce snapshots (r/atom {}))
 (defonce simulations (r/atom (sorted-map)))
 (defonce local (r/atom {}))

--- a/src/main/nyancad/mosaic/extension.cljc
+++ b/src/main/nyancad/mosaic/extension.cljc
@@ -9,6 +9,7 @@
             ["path" :as path]
             ["child_process" :as cp]
             [clojure.string :as str]
+            [nyancad.mosaic.jsatom.bridge :as bridge]
             [cljs.core.async :refer [go go-loop <! >! chan put! promise-chan]]
             [cljs.core.async.interop :refer-macros [<p!]]))
 
@@ -71,31 +72,26 @@
   [^js document]
   (.getText document))
 
+(deftype VscodeDoc [^js document]
+  bridge/IHostDocument
+  (-position-at    [_ offset]    (.positionAt document offset))
+  (-make-range     [_ start end] (vscode/Range. start end))
+  (-get-text-range [_ range]     (.getText document range)))
+
 (defn- apply-updates
   "Validate oldcontent and apply JSON edit operations to a VSCode WorkspaceEdit.
    Returns true if all edits were valid and added, false if rejected.
-   Extracted from go-loop so ^js hints survive (go macro strips them)."
+   Extracted from go-loop so ^js hints survive (go macro strips them).
+   The oldcontent validation + range computation is shared with the jsatom
+   test harness via nyancad.mosaic.jsatom.bridge/build-edit-ops."
   [^js document ^js edit updates]
-  (let [ops (mapv (fn [^js up]
-                    (let [offset (.-offset up)
-                          length (.-length up)
-                          content (.-content up)
-                          old-content (.-oldcontent up)
-                          start (.positionAt document offset)
-                          end (.positionAt document (+ offset (if old-content
-                                                                (.-length old-content)
-                                                                length)))
-                          range (vscode/Range. start end)]
-                      (when (or (nil? old-content)
-                                (= old-content (.getText document range)))
-                        {:range range :content (or content "")})))
-                  updates)]
-    (if (every? some? ops)
+  (let [ops (bridge/build-edit-ops (VscodeDoc. document) updates)]
+    (if (= bridge/rejected ops)
+      (do (js/console.log "Rejected edit batch: content mismatch")
+          false)
       (do (doseq [{:keys [range content]} ops]
             (.replace edit (.-uri document) range content))
-          true)
-      (do (js/console.log "Rejected edit batch: content mismatch")
-          false))))
+          true))))
 
 ;; ---------------------------------------------------------------------------
 ;; Atom channel — bidirectional sync between a TextDocument and a JsAtom
@@ -108,12 +104,20 @@
    Returns {:edit-queue chan, :disposable disposable}."
   [^js webview ^js document group]
   (let [edit-queue (chan 32)]
-    ;; Process edit queue with oldcontent validation
+    ;; Process edit queue with oldcontent validation. On rejection the webview
+    ;; has already advanced its optimistic state, so send it an authoritative
+    ;; resync snapshot instead of silently dropping the edit — otherwise the
+    ;; webview stays diverged from the document (see rejected-batch-resyncs).
     (go-loop []
       (when-let [update (<! edit-queue)]
         (let [edit (vscode/WorkspaceEdit.)]
-          (when (apply-updates document edit update)
-            (<p! (.. vscode/workspace (applyEdit edit)))))
+          (if (apply-updates document edit update)
+            (<p! (.. vscode/workspace (applyEdit edit)))
+            (.postMessage webview
+              #js{:type "resync"
+                  :group group
+                  :version (.-version document)
+                  :text (.getText document)})))
         (recur)))
     ;; Forward TextDocument changes as incremental edits
     (let [disposable
@@ -240,8 +244,10 @@
 
 (defn- get-html
   "Generate webview HTML for the schematic editor.
-   models-content is the initial JSON string from models.nyanlib."
-  [^js document ^js webview models-content]
+   models-content is the initial JSON string from models.nyanlib.
+   The document/models version inputs seed the webview JsAtoms' self-echo
+   guard so it stays in lockstep with the host document versions."
+  [^js document ^js webview models-content models-version]
   (let [out-uri (fn [file]
                   (.asWebviewUri webview (uri-join bundle-uri file)))
         nonce (get-nonce)
@@ -260,8 +266,10 @@
 </head>
 <body>
   <input type=\"hidden\" id=\"document\" value=\"" (js/encodeURIComponent (.getText document)) "\">
+  <input type=\"hidden\" id=\"document-version\" value=\"" (.-version document) "\">
   <input type=\"hidden\" id=\"group\" value=\"" (uri-basename (.-uri document) ".nyancir") "\">
   <input type=\"hidden\" id=\"models\" value=\"" (js/encodeURIComponent models-content) "\">
+  <input type=\"hidden\" id=\"models-version\" value=\"" models-version "\">
   <div class=\"mosaic-app mosaic-editor\"></div>
   <script nonce=\"" nonce "\" src=\"" (out-uri "shared.js") "\"></script>
   <script nonce=\"" nonce "\" src=\"" (out-uri "editor.js") "\"></script>
@@ -289,6 +297,7 @@
 </head>
 <body>
   <input type=\"hidden\" id=\"document\" value=\"" (js/encodeURIComponent (.getText document)) "\">
+  <input type=\"hidden\" id=\"document-version\" value=\"" (.-version document) "\">
   <div class=\"mosaic-app mosaic-libman\"></div>
   <script nonce=\"" nonce "\" src=\"" (out-uri "shared.js") "\"></script>
   <script nonce=\"" nonce "\" src=\"" (out-uri "libman.js") "\"></script>
@@ -419,7 +428,7 @@
                 (set! (.-options webview)
                       #js{:enableScripts true
                           :localResourceRoots #js[bundle-uri]})
-                (set! (.-html webview) (get-html document webview models-content))
+                (set! (.-html webview) (get-html document webview models-content (.-version nyanlib-doc)))
 
                 ;; Create atom channels for schematic and models documents
                 (let [schem-ch (create-atom-channel webview document "schematic")

--- a/src/main/nyancad/mosaic/jsatom.cljs
+++ b/src/main/nyancad/mosaic/jsatom.cljs
@@ -6,75 +6,32 @@
   "Reactive atom backed by a VSCode text document buffer.
    Uses jsonc-parser to apply edits and sync state with the extension host.
    Top-level keys are strings (matching PouchDB format), inner values use keyword keys.
-   Each JsAtom has a group field for message routing in multi-atom webviews."
-  (:require ["jsonc-parser" :as jsonc]
-            [nyancad.mosaic.jsatom.util :refer [doc->state]]
-            [cljs.core.async :refer [go put! promise-chan]]
-            reagent.ratom))
+   Each JsAtom has a group field for message routing in multi-atom webviews.
+
+   The edit protocol itself (JsAtom, edit generation, echo application) lives in
+   nyancad.mosaic.jsatom.protocol so it can be unit-tested under the :test build
+   without js/window or js/acquireVsCodeApi. This namespace keeps only the
+   VSCode-specific wiring: the acquireVsCodeApi transport, the window message
+   listener, and the read-file request/response channel."
+  (:require [nyancad.mosaic.jsatom.protocol :as protocol]
+            [cljs.core.async :refer [go put! promise-chan]]))
 
 (defonce vscode (js/acquireVsCodeApi))
-
-(defn- pouch-swap! [^js ja f x & args]
-  (let [old @(.-cache ja)
-        data (apply f old x args)]
-    (when-let [v (.-validator ja)]
-      (when-not (v data)
-        (throw (ex-info "Validator rejected reference state" {:val data}))))
-    (reset! (.-cache ja) data)
-    (let [grp (.-group ja)
-          msg (fn [path value]
-                (swap! (.-version ja) inc)
-                (let [update (jsonc/modify @(.-document ja)
-                                           (clj->js path)
-                                           (or (clj->js value) js/undefined)
-                                           #js{:formattingOptions #js{:tabSize 2 :insertSpaces true}})]
-                  (doseq [up update]
-                    (set! (.-oldcontent ^js up)
-                          (subs @(.-document ja)
-                                (.-offset up)
-                                (+ (.-offset up) (.-length up)))))
-                  (.postMessage vscode #js{:type "update" :group grp :update update})
-                  (swap! (.-document ja) jsonc/applyEdits update)))]
-      (cond
-        (set? x) (doseq [k x] (msg [k] (get data k)))
-        (map? x) (doseq [k (keys x)] (msg [k] (get data k)))
-        (coll? x) (msg x (get-in data x))
-        :else (msg [x] (get data x))))))
-
-(deftype JsAtom [group document version cache ^:mutable validator]
-  IAtom
-
-  IDeref
-  (-deref [_this] @cache)
-
-  ISwap
-  (-swap! [_a _f]         (throw (js/Error "JsAtom assumes first argument is a key")))
-  (-swap! [a f x]        (pouch-swap! a f x))
-  (-swap! [a f x y]      (pouch-swap! a f x y))
-  (-swap! [a f x y more] (apply pouch-swap! a f x y more))
-
-  IWatchable
-  (-notify-watches [_this old new] (-notify-watches cache old new))
-  (-add-watch [this key f]         (-add-watch cache key (fn [key _ old new] (f key this old new))))
-  (-remove-watch [_this key]       (-remove-watch cache key)))
 
 (defn json-atom
   "Create a JsAtom from a JSON document string, tagged with a group name.
    Listens for update messages from the VSCode extension host,
-   filtering by group to support multiple atoms in one webview."
+   filtering by group to support multiple atoms in one webview.
+   `init-version` is the host document's VSCode version at load time, so the
+   self-echo guard stays in lockstep with the host (defaults to 1)."
   ([group doc] (json-atom group doc (atom {})))
-  ([group doc cache]
-   (reset! cache (doc->state doc))
-   (let [ja (JsAtom. group (atom doc) (atom 1) cache nil)]
+  ([group doc cache] (json-atom group doc cache 1))
+  ([group doc cache init-version]
+   (let [{:keys [atom receive!]}
+         (protocol/make-json-atom group doc cache #(.postMessage vscode %) init-version)]
      (.addEventListener js/window "message"
-       (fn [^js event]
-         (when (and (= (.. event -data -type) "update")
-                    (= (.. event -data -group) group)
-                    (> (.. event -data -version) @(.-version ja)))
-           (swap! (.-document ja) jsonc/applyEdits (.. event -data -update))
-           (reset! (.-version ja) (.. event -data -version))
-           (reset! cache (doc->state @(.-document ja))))))
-     ja)))
+       (fn [^js event] (receive! (.-data event))))
+     atom)))
 
 ;; --- Request/response for read-file messages ---
 

--- a/src/main/nyancad/mosaic/jsatom.cljs
+++ b/src/main/nyancad/mosaic/jsatom.cljs
@@ -18,6 +18,14 @@
 
 (defonce vscode (js/acquireVsCodeApi))
 
+(defn injected-version
+  "Read a host document version from a hidden input the extension injects,
+   defaulting to 1 when the input is absent or unparseable so the self-echo
+   guard degrades to its old behaviour rather than breaking."
+  [id]
+  (let [v (some-> (js/document.getElementById id) .-value (js/parseInt 10))]
+    (if (and (number? v) (not (js/isNaN v))) v 1)))
+
 (defn json-atom
   "Create a JsAtom from a JSON document string, tagged with a group name.
    Listens for update messages from the VSCode extension host,

--- a/src/main/nyancad/mosaic/jsatom/bridge.cljc
+++ b/src/main/nyancad/mosaic/jsatom/bridge.cljc
@@ -1,0 +1,52 @@
+; SPDX-FileCopyrightText: 2026 Pepijn de Vos
+;
+; SPDX-License-Identifier: MPL-2.0
+
+(ns nyancad.mosaic.jsatom.bridge
+  "Host-side validation core shared between the VSCode extension host
+   (nyancad.mosaic.extension) and the jsatom test harness.
+
+   Extracts the oldcontent check + range computation from the extension's
+   apply-updates, parameterized over IHostDocument so the same logic runs
+   against a real vscode.TextDocument in production and against Microsoft's
+   vscode-languageserver-textdocument model under the :test build. The async
+   apply (WorkspaceEdit) and event-driven change forwarding stay with each
+   caller — only the pure validation lives here.")
+
+(defprotocol IHostDocument
+  "The three primitives apply-updates needs from a text document model."
+  (-position-at    [this offset] "Offset -> position.")
+  (-make-range     [this start end] "Two positions -> a range value get-text understands.")
+  (-get-text-range [this range] "getText(range), for the oldcontent comparison."))
+
+(def rejected
+  "Sentinel returned by build-edit-ops when an edit batch fails validation."
+  ::rejected)
+
+(defn build-edit-ops
+  "Validate each jsonc update's oldcontent against host-doc and compute the
+   {:range :content} replacements to apply. `updates` is the js array posted by
+   the webview (each op has :offset :length :content and optionally :oldcontent).
+
+   Returns the ops vector when every op is valid (an empty batch yields []),
+   or `rejected` if any op's oldcontent no longer matches the document — the
+   whole batch is dropped in that case, matching the original apply-updates."
+  [host-doc updates]
+  (let [ops (mapv (fn [^js up]
+                    (let [offset      (.-offset up)
+                          length      (.-length up)
+                          content     (.-content up)
+                          old-content (.-oldcontent up)
+                          start       (-position-at host-doc offset)
+                          end         (-position-at host-doc
+                                                    (+ offset (if old-content
+                                                                (.-length old-content)
+                                                                length)))
+                          range       (-make-range host-doc start end)]
+                      (when (or (nil? old-content)
+                                (= old-content (-get-text-range host-doc range)))
+                        {:range range :content (or content "")})))
+                  updates)]
+    (if (every? some? ops)
+      ops
+      rejected)))

--- a/src/main/nyancad/mosaic/jsatom/protocol.cljs
+++ b/src/main/nyancad/mosaic/jsatom/protocol.cljs
@@ -1,0 +1,136 @@
+; SPDX-FileCopyrightText: 2026 Pepijn de Vos
+;
+; SPDX-License-Identifier: MPL-2.0
+
+(ns nyancad.mosaic.jsatom.protocol
+  "Webview-side core of nyancad.mosaic.jsatom, split out so the edit protocol
+   is testable under shadow-cljs's :test build (Node) without js/window or
+   js/acquireVsCodeApi.
+
+   Mirrors the nyancad.hipflask.util / jsatom.util split: the postMessage and
+   window-listener plumbing stays in jsatom.cljs; the JSON edit generation, the
+   host->webview echo application, and the JsAtom deftype live here, driven
+   through an injected `post!` fn so tests can supply an in-memory transport."
+  (:require ["jsonc-parser" :as jsonc]
+            [nyancad.mosaic.jsatom.util :refer [doc->state]]
+            reagent.ratom))
+
+(defn value->js
+  "Convert a Clojure value to the JS value jsonc/modify expects, where
+   js/undefined means \"delete this key\".
+
+   Only nil deletes. The historical `(or (clj->js value) js/undefined)` also
+   collapsed boolean `false` to js/undefined (0 and \"\" happen to survive,
+   since they are truthy under ClojureScript's `or`), silently deleting a key
+   whenever a field was set to false — see write-false-survives in
+   jsatom_test. clj->js of false/0/\"\" round-trips correctly through jsonc."
+  [value]
+  (if (nil? value) js/undefined (clj->js value)))
+
+(defn edit-message
+  "Compute the jsonc text edits needed to set `path` to `value` in `doc-str`.
+   Returns {:ops <js array of edits, each with :oldcontent set to the substring
+   it overwrites> :doc' <resulting document string>}. Pure: no posting, no
+   atom mutation."
+  [doc-str path value]
+  (let [ops (jsonc/modify doc-str
+                          (clj->js path)
+                          (value->js value)
+                          #js{:formattingOptions #js{:tabSize 2 :insertSpaces true}})]
+    (doseq [^js up ops]
+      (set! (.-oldcontent up)
+            (subs doc-str (.-offset up) (+ (.-offset up) (.-length up)))))
+    {:ops ops :doc' (jsonc/applyEdits doc-str ops)}))
+
+(defn changed-paths
+  "Given the swap key-selector `x` and the resulting `data` map, return the
+   seq of [path value] pairs to emit as edit messages. Mirrors the set/map/
+   coll/scalar dispatch in the original pouch-swap!."
+  [x data]
+  (cond
+    (set? x)  (map (fn [k] [[k] (get data k)]) x)
+    (map? x)  (map (fn [k] [[k] (get data k)]) (keys x))
+    (coll? x) [[x (get-in data x)]]
+    :else     [[[x] (get data x)]]))
+
+(defn apply-echo
+  "Apply a host->webview \"update\" message to the webview's {:doc :version}.
+   Only applies when the incoming version is strictly greater than the current
+   one (the version guard). Returns
+   {:applied? bool :doc <string> :version <n> :cache <state>}."
+  [{:keys [doc version]} ^js incoming]
+  (let [incoming-version (.-version incoming)]
+    (if (> incoming-version version)
+      (let [doc' (jsonc/applyEdits doc (.-update incoming))]
+        {:applied? true :doc doc' :version incoming-version :cache (doc->state doc')})
+      {:applied? false :doc doc :version version})))
+
+(defn- pouch-swap! [^js ja f x & args]
+  (let [old @(.-cache ja)
+        data (apply f old x args)]
+    (when-let [v (.-validator ja)]
+      (when-not (v data)
+        (throw (ex-info "Validator rejected reference state" {:val data}))))
+    (reset! (.-cache ja) data)
+    (let [grp (.-group ja)
+          post (.-post ja)]
+      (doseq [[path value] (changed-paths x data)]
+        (swap! (.-version ja) inc)
+        (let [{:keys [ops doc']} (edit-message @(.-document ja) path value)]
+          (post #js{:type "update" :group grp :update ops})
+          (reset! (.-document ja) doc'))))))
+
+(deftype JsAtom [group document version cache post ^:mutable validator]
+  IAtom
+
+  IDeref
+  (-deref [_this] @cache)
+
+  ISwap
+  (-swap! [_a _f]        (throw (js/Error "JsAtom assumes first argument is a key")))
+  (-swap! [a f x]        (pouch-swap! a f x))
+  (-swap! [a f x y]      (pouch-swap! a f x y))
+  (-swap! [a f x y more] (apply pouch-swap! a f x y more))
+
+  IWatchable
+  (-notify-watches [_this old new] (-notify-watches cache old new))
+  (-add-watch [this key f]         (-add-watch cache key (fn [key _ old new] (f key this old new))))
+  (-remove-watch [_this key]       (-remove-watch cache key)))
+
+(defn make-json-atom
+  "Build a JsAtom plus its host-message receiver.
+
+   `post!` is called with a #js update message for each webview->host edit.
+   `init-version` seeds the version counter from the host document's VSCode
+   version so the self-echo guard stays in lockstep even when the document was
+   opened at a version > 1 (defaults to 1 for a freshly opened document).
+
+   Returns {:atom <JsAtom> :receive! (fn [^js msg])}, where `receive!` should be
+   invoked for every host->webview message; it filters by group, applies
+   accepted \"update\" echoes, and adopts authoritative \"resync\" snapshots the
+   host sends when it had to reject an edit."
+  ([group doc cache post!] (make-json-atom group doc cache post! 1))
+  ([group doc cache post! init-version]
+   (reset! cache (doc->state doc))
+   (let [document (atom doc)
+         version  (atom init-version)
+         ja       (JsAtom. group document version cache post! nil)
+         receive! (fn [^js msg]
+                    (when (= (.-group msg) group)
+                      (case (.-type msg)
+                        "update"
+                        (let [{:keys [applied?] :as result}
+                              (apply-echo {:doc @document :version @version} msg)]
+                          (when applied?
+                            (reset! document (:doc result))
+                            (reset! version  (:version result))
+                            (reset! cache    (:cache result))))
+
+                        "resync"
+                        (let [text (.-text msg)]
+                          (reset! document text)
+                          (reset! version  (.-version msg))
+                          (reset! cache    (doc->state text)))
+
+                        nil)))]
+     {:atom ja :receive! receive!})))

--- a/src/main/nyancad/mosaic/jsatom/protocol.cljs
+++ b/src/main/nyancad/mosaic/jsatom/protocol.cljs
@@ -16,14 +16,10 @@
             reagent.ratom))
 
 (defn value->js
-  "Convert a Clojure value to the JS value jsonc/modify expects, where
-   js/undefined means \"delete this key\".
-
-   Only nil deletes. The historical `(or (clj->js value) js/undefined)` also
-   collapsed boolean `false` to js/undefined (0 and \"\" happen to survive,
-   since they are truthy under ClojureScript's `or`), silently deleting a key
-   whenever a field was set to false — see write-false-survives in
-   jsatom_test. clj->js of false/0/\"\" round-trips correctly through jsonc."
+  "Convert a Clojure value to the JS value jsonc/modify expects. Only nil maps to
+   js/undefined (delete the key); everything else — including false, 0 and \"\" —
+   round-trips through clj->js. (A prior `(or (clj->js v) js/undefined)` collapsed
+   boolean false to a delete; see falsy-values-survive in jsatom_test.)"
   [value]
   (if (nil? value) js/undefined (clj->js value)))
 
@@ -47,23 +43,22 @@
    seq of [path value] pairs to emit as edit messages. Mirrors the set/map/
    coll/scalar dispatch in the original pouch-swap!."
   [x data]
-  (cond
-    (set? x)  (map (fn [k] [[k] (get data k)]) x)
-    (map? x)  (map (fn [k] [[k] (get data k)]) (keys x))
-    (coll? x) [[x (get-in data x)]]
-    :else     [[[x] (get data x)]]))
+  (let [entry (fn [k] [[k] (get data k)])]
+    (cond
+      (set? x)  (map entry x)
+      (map? x)  (map entry (keys x))
+      (coll? x) [[x (get-in data x)]]
+      :else     [[[x] (get data x)]])))
 
 (defn apply-echo
-  "Apply a host->webview \"update\" message to the webview's {:doc :version}.
-   Only applies when the incoming version is strictly greater than the current
-   one (the version guard). Returns
-   {:applied? bool :doc <string> :version <n> :cache <state>}."
-  [{:keys [doc version]} ^js incoming]
+  "Apply a host->webview \"update\" message to the webview's current document
+   string and version. Returns {:doc :version :cache} when the incoming version
+   is strictly greater than the current one (the version guard), else nil."
+  [doc version ^js incoming]
   (let [incoming-version (.-version incoming)]
-    (if (> incoming-version version)
+    (when (> incoming-version version)
       (let [doc' (jsonc/applyEdits doc (.-update incoming))]
-        {:applied? true :doc doc' :version incoming-version :cache (doc->state doc')})
-      {:applied? false :doc doc :version version})))
+        {:doc doc' :version incoming-version :cache (doc->state doc')}))))
 
 (defn- pouch-swap! [^js ja f x & args]
   (let [old @(.-cache ja)
@@ -119,12 +114,10 @@
                     (when (= (.-group msg) group)
                       (case (.-type msg)
                         "update"
-                        (let [{:keys [applied?] :as result}
-                              (apply-echo {:doc @document :version @version} msg)]
-                          (when applied?
-                            (reset! document (:doc result))
-                            (reset! version  (:version result))
-                            (reset! cache    (:cache result))))
+                        (when-let [res (apply-echo @document @version msg)]
+                          (reset! document (:doc res))
+                          (reset! version  (:version res))
+                          (reset! cache    (:cache res)))
 
                         "resync"
                         (let [text (.-text msg)]

--- a/src/main/nyancad/mosaic/libman/platform_vscode.cljs
+++ b/src/main/nyancad/mosaic/libman/platform_vscode.cljs
@@ -6,7 +6,7 @@
   "JsAtom-backed platform module for the library manager (VS Code deployment)."
   (:require [reagent.core :as r]
             [reagent.dom.client :as rdc]
-            [nyancad.mosaic.jsatom :as jsatom :refer [json-atom vscode send-request!]]
+            [nyancad.mosaic.jsatom :as jsatom :refer [json-atom vscode send-request! injected-version]]
             [nyancad.mosaic.common :as cm]
             [nyancad.hipflask.util :refer [json->clj]]
             [cljs.core.async :refer [go <!]]))
@@ -16,13 +16,6 @@
 (defonce root (rdc/create-root (.querySelector js/document ".mosaic-app.mosaic-libman")))
 
 ;; --- State ---
-
-(defn- injected-version
-  "Read a host document version injected into a hidden input, defaulting to 1
-   when absent or unparseable."
-  [id]
-  (let [v (some-> (js/document.getElementById id) .-value (js/parseInt 10))]
-    (if (or (nil? v) (js/isNaN v)) 1 v)))
 
 (defonce modeldb (json-atom "models"
                    (js/decodeURIComponent (.-value (js/document.getElementById "document")))

--- a/src/main/nyancad/mosaic/libman/platform_vscode.cljs
+++ b/src/main/nyancad/mosaic/libman/platform_vscode.cljs
@@ -17,9 +17,17 @@
 
 ;; --- State ---
 
+(defn- injected-version
+  "Read a host document version injected into a hidden input, defaulting to 1
+   when absent or unparseable."
+  [id]
+  (let [v (some-> (js/document.getElementById id) .-value (js/parseInt 10))]
+    (if (or (nil? v) (js/isNaN v)) 1 v)))
+
 (defonce modeldb (json-atom "models"
                    (js/decodeURIComponent (.-value (js/document.getElementById "document")))
-                   (r/atom {})))
+                   (r/atom {})
+                   (injected-version "document-version")))
 
 (defonce syncactive (r/atom false))
 (defonce remotemodeldb (r/atom {}))

--- a/src/test/nyancad/mosaic/jsatom_test.cljs
+++ b/src/test/nyancad/mosaic/jsatom_test.cljs
@@ -20,11 +20,10 @@
    fix."
   (:require [cljs.test :refer [deftest is testing async]]
             ["vscode-languageserver-textdocument" :as lsp]
-            ["jsonc-parser" :as jsonc]
             [nyancad.mosaic.jsatom.protocol :as protocol]
             [nyancad.mosaic.jsatom.bridge :as bridge]
             [nyancad.mosaic.jsatom.util :refer [doc->state]]
-            [cljs.core.async :refer [go go-loop chan <! >! put! close! timeout]]))
+            [cljs.core.async :refer [go go-loop chan <! put! close! timeout]]))
 
 ;; ---------------------------------------------------------------------------
 ;; Host document — real TextDocument behind the IHostDocument protocol
@@ -37,7 +36,6 @@
   (-get-text-range [_ range]     (.getText doc range)))
 
 (defn- host-text [h] (.getText ^js @(:host h)))
-(defn- host-version [h] (.-version ^js @(:host h)))
 
 (defn- valid-json?
   "Strict JSON validity (not the lenient jsonc parse) — catches corruption

--- a/src/test/nyancad/mosaic/jsatom_test.cljs
+++ b/src/test/nyancad/mosaic/jsatom_test.cljs
@@ -1,0 +1,437 @@
+; SPDX-FileCopyrightText: 2026 Pepijn de Vos
+;
+; SPDX-License-Identifier: MPL-2.0
+
+(ns nyancad.mosaic.jsatom-test
+  "Round-trip tests for the jsatom webview<->host edit protocol, run against
+   Microsoft's real shared text-document model (vscode-languageserver-textdocument)
+   instead of Electron. The webview core (nyancad.mosaic.jsatom.protocol) and the
+   host validation (nyancad.mosaic.jsatom.bridge/build-edit-ops) are the actual
+   production code; only the message transport and the host's apply/forward
+   orchestration are re-created here, mirroring extension.cljc/create-atom-channel.
+
+   The document (an LspDoc wrapping a real TextDocument) exercises the genuine
+   positionAt / getText(range) / incremental-update algorithm, so the offset math
+   that governs whether an edit lands correctly is not faked.
+
+   These tests do not presuppose bugs — they assert the protocol's invariants
+   (host stays valid JSON; host and webview converge). Where an assertion fails,
+   that is a reproduced corruption, and the failing scenario is the spec for the
+   fix."
+  (:require [cljs.test :refer [deftest is testing async]]
+            ["vscode-languageserver-textdocument" :as lsp]
+            ["jsonc-parser" :as jsonc]
+            [nyancad.mosaic.jsatom.protocol :as protocol]
+            [nyancad.mosaic.jsatom.bridge :as bridge]
+            [nyancad.mosaic.jsatom.util :refer [doc->state]]
+            [cljs.core.async :refer [go go-loop chan <! >! put! close! timeout]]))
+
+;; ---------------------------------------------------------------------------
+;; Host document — real TextDocument behind the IHostDocument protocol
+;; ---------------------------------------------------------------------------
+
+(deftype LspDoc [^js doc]
+  bridge/IHostDocument
+  (-position-at    [_ offset]    (.positionAt doc offset))
+  (-make-range     [_ start end] #js{:start start :end end})
+  (-get-text-range [_ range]     (.getText doc range)))
+
+(defn- host-text [h] (.getText ^js @(:host h)))
+(defn- host-version [h] (.-version ^js @(:host h)))
+
+(defn- valid-json?
+  "Strict JSON validity (not the lenient jsonc parse) — catches corruption
+   that jsonc would silently tolerate."
+  [s]
+  (try (js/JSON.parse s) true (catch :default _ false)))
+
+(defn- converged?
+  "Host document parses to the same state the webview believes it holds."
+  [h]
+  (= (doc->state (host-text h)) @(:cache h)))
+
+;; ---------------------------------------------------------------------------
+;; Harness — webview core + in-memory bus + real host document
+;; ---------------------------------------------------------------------------
+
+(defn- make-harness
+  "Wire a JsAtom (via the real protocol/make-json-atom) to a real TextDocument
+   through an in-memory message bus. `init-version` seeds the host document's
+   VSCode version (the webview counter always starts at 1, as in production)."
+  ([doc] (make-harness doc 1))
+  ([doc init-version]
+   (let [bus   (atom [])
+         host  (atom (.create lsp/TextDocument "mem://schematic" "json" init-version doc))
+         cache (atom {})
+         post! (fn [m] (swap! bus conj {:dir :host :msg m}))
+         {ja :atom receive! :receive!}
+         ;; seed the webview version from the host document version, as the
+         ;; extension injects it in production (fixes open-at-version>1 drift)
+         (protocol/make-json-atom "schematic" doc cache post! init-version)]
+     {:bus bus :host host :cache cache :ja ja :receive! receive!})))
+
+(defn- host-apply!
+  "Mirror of extension.cljc/create-atom-channel's edit-queue + change-forward:
+   validate via the shared bridge, apply to the real TextDocument (descending by
+   offset so original-relative offsets stay valid), then enqueue the host->webview
+   echo tagged with the new document version. Returns :applied or :rejected."
+  [h ^js msg]
+  (let [^js doc @(:host h)
+        ops     (bridge/build-edit-ops (LspDoc. doc) (.-update msg))]
+    (if (= bridge/rejected ops)
+      ;; mirror extension.cljc: on reject, send an authoritative resync snapshot
+      (do (swap! (:bus h) conj
+                 {:dir :webview
+                  :msg #js{:type "resync" :group (.-group msg)
+                           :version (.-version doc) :text (.getText doc)}})
+          :rejected)
+      (let [sorted  (sort-by (fn [op] (.offsetAt doc (.-start ^js (:range op)))) > ops)
+            changes (into-array (map (fn [op] #js{:range (:range op) :text (:content op)}) sorted))
+            new-ver (inc (.-version doc))]
+        (reset! (:host h) (.update lsp/TextDocument doc changes new-ver))
+        (swap! (:bus h) conj
+               {:dir :webview
+                :msg #js{:type "update" :group (.-group msg)
+                         :version new-ver :update (.-update msg)}})
+        :applied))))
+
+(defn- external-edit!
+  "Simulate an edit from outside the webview (user typing, another editor): replace
+   [offset, offset+old-len) with `text` on the host, bump version, forward the echo.
+   `offset`/`old-len` are against the CURRENT host document."
+  [h offset old-len text]
+  (let [^js doc @(:host h)
+        start   (.positionAt doc offset)
+        end     (.positionAt doc (+ offset old-len))
+        new-ver (inc (.-version doc))]
+    (reset! (:host h)
+            (.update lsp/TextDocument doc
+                     (into-array [#js{:range #js{:start start :end end} :text text}])
+                     new-ver))
+    (swap! (:bus h) conj
+           {:dir :webview
+            :msg #js{:type "update" :group "schematic" :version new-ver
+                     :update #js[#js{:offset offset :length old-len :content text}]}})))
+
+(defn- deliver-one! [h item]
+  (case (:dir item)
+    :host    (host-apply! h (:msg item))
+    :webview ((:receive! h) (:msg item))))
+
+(defn- drain!
+  "Deliver every queued message FIFO until the bus is empty (host applies enqueue
+   echoes, which then get delivered too). Guarded against runaway loops."
+  [h]
+  (loop [n 0]
+    (cond
+      (empty? @(:bus h)) n
+      (> n 100000)       (throw (ex-info "drain! runaway" {}))
+      :else (let [item (first @(:bus h))]
+              (swap! (:bus h) (fn [v] (subvec v 1)))
+              (deliver-one! h item)
+              (recur (inc n))))))
+
+(defn- pop-idx!
+  "Remove and deliver the item at index i in the bus (for reorder scenarios)."
+  [h i]
+  (let [item (nth @(:bus h) i)]
+    (swap! (:bus h) (fn [v] (into (subvec v 0 i) (subvec v (inc i)))))
+    (deliver-one! h item)
+    item))
+
+;; A device with explicit x/y so doc->state's x/y backfill can't mask a diff.
+(defn- doc1 []
+  (js/JSON.stringify
+    #js{"R1" #js{"type" "resistor" "name" "R1" "x" 5 "y" 7}}))
+
+;; ---------------------------------------------------------------------------
+;; 1. Correctness invariants — single writer, edits fully drained
+;; ---------------------------------------------------------------------------
+
+(deftest write-string-roundtrips
+  (let [h (make-harness (doc1))]
+    (swap! (:ja h) assoc-in ["R1" :name] "R99")
+    (drain! h)
+    (is (valid-json? (host-text h)))
+    (is (converged? h))
+    (is (= "R99" (get-in (doc->state (host-text h)) ["R1" :name])))))
+
+(deftest write-number-roundtrips
+  (let [h (make-harness (doc1))]
+    (swap! (:ja h) assoc-in ["R1" :x] 42)
+    (drain! h)
+    (is (converged? h))
+    (is (= 42 (get-in (doc->state (host-text h)) ["R1" :x])))))
+
+(deftest write-nested-map-roundtrips
+  (let [h (make-harness (doc1))]
+    (swap! (:ja h) assoc-in ["R1" :props] {:resistance "10k"})
+    (drain! h)
+    (is (valid-json? (host-text h)))
+    (is (converged? h))
+    (is (= "10k" (get-in (doc->state (host-text h)) ["R1" :props :resistance])))))
+
+(deftest write-new-top-level-key
+  (let [h (make-harness (doc1))]
+    (swap! (:ja h) assoc "C1" {:type "capacitor" :name "C1" :x 1 :y 2})
+    (drain! h)
+    (is (valid-json? (host-text h)))
+    (is (converged? h))
+    (is (contains? (doc->state (host-text h)) "C1"))))
+
+(deftest nil-value-deletes-key
+  (testing "assoc-in a nil value removes the key (intended delete semantics)"
+    (let [h (make-harness (doc1))]
+      (swap! (:ja h) assoc-in ["R1" :name] nil)
+      (drain! h)
+      (is (valid-json? (host-text h)))
+      (is (not (contains? (get (doc->state (host-text h)) "R1") :name))))))
+
+(deftest dissoc-top-level-key-deletes
+  (let [h (make-harness (doc1))]
+    (swap! (:ja h) assoc "C1" {:type "capacitor" :name "C1" :x 1 :y 2})
+    (drain! h)
+    (swap! (:ja h) dissoc "C1")
+    (drain! h)
+    (is (valid-json? (host-text h)))
+    (is (not (contains? (doc->state (host-text h)) "C1")))))
+
+;; Falsy values: probe whether false / 0 / "" survive or get deleted.
+;; (Avoid :x/:y, which doc->state backfills and would mask a lost key.)
+(deftest write-false-survives
+  (let [h (make-harness (doc1))]
+    (swap! (:ja h) assoc-in ["R1" :mirror] false)
+    (drain! h)
+    (is (valid-json? (host-text h)))
+    (is (contains? (get (doc->state (host-text h)) "R1") :mirror)
+        "writing false must not delete the key")
+    (is (= false (get-in (doc->state (host-text h)) ["R1" :mirror])))
+    (is (converged? h))))
+
+(deftest write-zero-survives
+  (let [h (make-harness (doc1))]
+    (swap! (:ja h) assoc-in ["R1" :rotation] 0)
+    (drain! h)
+    (is (contains? (get (doc->state (host-text h)) "R1") :rotation)
+        "writing 0 must not delete the key")
+    (is (= 0 (get-in (doc->state (host-text h)) ["R1" :rotation])))
+    (is (converged? h))))
+
+(deftest write-empty-string-survives
+  (let [h (make-harness (doc1))]
+    (swap! (:ja h) assoc-in ["R1" :label] "")
+    (drain! h)
+    (is (contains? (get (doc->state (host-text h)) "R1") :label)
+        "writing \"\" must not delete the key")
+    (is (= "" (get-in (doc->state (host-text h)) ["R1" :label])))
+    (is (converged? h))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Batched-edit stacking
+;; ---------------------------------------------------------------------------
+
+(deftest multi-key-swap-stacks
+  (testing "a single swap! merge touching many keys stacks all edits"
+    (let [h (make-harness (doc1))]
+      (swap! (:ja h) merge {"C1" {:type "capacitor" :name "C1" :x 1 :y 1}
+                            "L1" {:type "inductor"  :name "L1" :x 2 :y 2}
+                            "D1" {:type "diode"     :name "D1" :x 3 :y 3}})
+      (drain! h)
+      (is (valid-json? (host-text h)))
+      (is (converged? h))
+      (let [state (doc->state (host-text h))]
+        (is (every? #(contains? state %) ["R1" "C1" "L1" "D1"]))))))
+
+(deftest successive-swaps-accumulate
+  (testing "a sequence of independent swaps all land, in order"
+    (let [h (make-harness (doc1))]
+      (doseq [[k v] [["C1" {:type "capacitor" :name "C1" :x 1 :y 1}]
+                     ["L1" {:type "inductor"  :name "L1" :x 2 :y 2}]
+                     ["D1" {:type "diode"     :name "D1" :x 3 :y 3}]]]
+        (swap! (:ja h) assoc k v)
+        (drain! h))
+      (is (valid-json? (host-text h)))
+      (is (converged? h))
+      (is (= 4 (count (doc->state (host-text h))))))))
+
+(deftest interleaved-batches-stack
+  (testing "several batched swaps queued before any delivery still stack"
+    (let [h (make-harness (doc1))]
+      (swap! (:ja h) assoc-in ["R1" :x] 10)
+      (swap! (:ja h) assoc "C1" {:type "capacitor" :name "C1" :x 1 :y 1})
+      (swap! (:ja h) assoc-in ["R1" :name] "RENAMED")
+      (drain! h)
+      (is (valid-json? (host-text h)))
+      (is (converged? h))
+      (let [state (doc->state (host-text h))]
+        (is (= 10 (get-in state ["R1" :x])))
+        (is (= "RENAMED" (get-in state ["R1" :name])))
+        (is (contains? state "C1"))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. Concurrency / conflict scenarios (deterministic ordering)
+;; ---------------------------------------------------------------------------
+
+(deftest disjoint-external-edit-converges
+  (testing "webview edits R1 while an external editor adds a disjoint key; in-order delivery converges"
+    (let [h (make-harness (doc1))]
+      ;; webview edit -> enqueues a :host msg
+      (swap! (:ja h) assoc-in ["R1" :name] "R2")
+      ;; deliver it so the host doc is up to date, then an external edit lands
+      (drain! h)
+      ;; external edit inserts a new key at the end of the object
+      (let [text  (host-text h)
+            ins-at (.lastIndexOf text "}")
+            frag  ",\n  \"NOTE1\": {\"type\": \"note\", \"x\": 0, \"y\": 0}"]
+        (external-edit! h ins-at 0 frag))
+      (drain! h)
+      (is (valid-json? (host-text h)))
+      (is (converged? h)))))
+
+(deftest rejected-batch-resyncs
+  (testing "an external edit mutates the field the webview is editing; the webview's stale edit is rejected and the webview resyncs to host truth"
+    (let [h (make-harness (doc1))]
+      ;; External editor changes R1's name VALUE (different length -> also shifts
+      ;; later offsets), queuing its echo. The webview does not know yet.
+      (let [text (host-text h)
+            off  (.indexOf text "\"R1\"" (.indexOf text "\"name\""))]
+        (external-edit! h off 4 "\"EXTERNAL\""))
+      ;; Webview edits the same field based on its now-stale document.
+      (swap! (:ja h) assoc-in ["R1" :name] "NEW")
+      (drain! h)
+      (is (valid-json? (host-text h)) "document must remain valid JSON")
+      (is (converged? h)
+          "after the reject-triggered resync, webview must match host truth")
+      (is (= "EXTERNAL" (get-in (doc->state (host-text h)) ["R1" :name]))
+          "host truth (the external edit) wins the conflict"))))
+
+(deftest initial-version-drift-self-echo
+  (testing "host document opened at version > 1: the webview seeds its counter from the host version, so its self-echo is still suppressed"
+    (let [h (make-harness (doc1) 5)]                        ; host starts at version 5, webview seeded to 5
+      (swap! (:ja h) assoc-in ["R1" :x] 10)
+      (drain! h)
+      (is (valid-json? (host-text h)))
+      (is (converged? h)
+          "self-echo must not be re-applied on top of the optimistic local edit")
+      (is (= 10 (get-in (doc->state (host-text h)) ["R1" :x]))))))
+
+(deftest external-edits-in-order-stack
+  (testing "two disjoint external edits, echoes delivered in order (as postMessage guarantees), both land"
+    (let [h (make-harness (doc1))]
+      (let [text   (host-text h)
+            ins-at (.lastIndexOf text "}")]
+        (external-edit! h ins-at 0 ",\"E1\":{\"type\":\"note\",\"x\":0,\"y\":0}"))
+      (let [text   (host-text h)
+            ins-at (.lastIndexOf text "}")]
+        (external-edit! h ins-at 0 ",\"E2\":{\"type\":\"note\",\"x\":1,\"y\":1}"))
+      (drain! h)
+      (is (valid-json? (host-text h)))
+      (is (converged? h))
+      (let [state (doc->state (host-text h))]
+        (is (contains? state "E1"))
+        (is (contains? state "E2"))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Data races — seeded, deterministic interleaving of concurrent writers
+;; ---------------------------------------------------------------------------
+
+(defn- make-rng
+  "Tiny seeded LCG so any failing interleaving is reproducible from its seed."
+  [seed]
+  (let [s (atom (bit-and seed 0x7fffffff))]
+    (fn [] (let [x (bit-and (+ (* @s 1103515245) 12345) 0x7fffffff)]
+             (reset! s x)
+             (/ x 0x7fffffff)))))
+
+(defn- rng-int [rng n] (min (dec n) (int (* (rng) n))))
+
+(defn- run-schedule!
+  "Cooperatively interleave concurrent writer 'threads' and async message
+   delivery, picking the next move with `rng`. Each writer is a vector of 0-arg
+   thunks (a swap! or external edit); a move is either 'advance a writer' or
+   'deliver a queued bus message'. Runs until all writers are exhausted and the
+   bus is empty — modelling multiple async threads racing on one document."
+  [h rng writers]
+  (let [ws (atom (vec writers))]
+    (loop [guard 0]
+      (let [pend  (keep-indexed (fn [i ts] (when (seq ts) i)) @ws)
+            n-msg (count @(:bus h))
+            moves (into (mapv (fn [i] [:writer i]) pend)
+                        (mapv (fn [j] [:msg j]) (range n-msg)))]
+        (when (and (seq moves) (< guard 100000))
+          (let [[kind arg] (nth moves (rng-int rng (count moves)))]
+            (case kind
+              :writer (let [thunk (first (nth @ws arg))]
+                        (swap! ws update arg subvec 1)
+                        (thunk))
+              :msg    (pop-idx! h arg))
+            (recur (inc guard))))))))
+
+(deftest fuzz-concurrent-writers-preserve-structure
+  (testing "many seeded interleavings of concurrent writers keep the doc valid and lose no device"
+    (let [base-keys #{"R1" "C1" "L1"}]
+      (doseq [seed (range 1 61)]
+        (let [rng (make-rng seed)
+              h   (make-harness
+                    (js/JSON.stringify
+                      #js{"R1" #js{"type" "resistor" "name" "R1" "x" 5 "y" 7}
+                          "C1" #js{"type" "capacitor" "name" "C1" "x" 1 "y" 1}
+                          "L1" #js{"type" "inductor" "name" "L1" "x" 2 "y" 2}}))
+              ;; two webview writers editing disjoint fields on distinct devices
+              writers [[(fn [] (swap! (:ja h) assoc-in ["R1" :name] "R1a"))
+                        (fn [] (swap! (:ja h) assoc-in ["R1" :name] "R1b"))]
+                       [(fn [] (swap! (:ja h) assoc-in ["C1" :name] "C1a"))
+                        (fn [] (swap! (:ja h) assoc-in ["L1" :name] "L1a"))]]]
+          (run-schedule! h rng writers)
+          (drain! h)
+          (is (valid-json? (host-text h))
+              (str "seed " seed ": host must stay valid JSON"))
+          (is (= base-keys (set (keys (doc->state (host-text h)))))
+              (str "seed " seed ": no device may be silently dropped")))))))
+
+;; ---------------------------------------------------------------------------
+;; 5. Genuine async threads (core.async) — two writers over channels on one doc
+;; ---------------------------------------------------------------------------
+
+(deftest async-concurrent-writers
+  (testing "two core.async writer threads swap! disjoint keys while a host go-loop applies edits"
+    (async done
+      (let [doc   (js/JSON.stringify
+                    #js{"R1" #js{"type" "resistor" "name" "R1" "x" 5 "y" 7}
+                        "C1" #js{"type" "capacitor" "name" "C1" "x" 1 "y" 1}})
+            host  (atom (.create lsp/TextDocument "mem://s" "json" 1 doc))
+            cache (atom {})
+            to-host (chan 64)
+            done-ch (chan 64)
+            post!  (fn [m] (put! to-host m))
+            {ja :atom receive! :receive!} (protocol/make-json-atom "schematic" doc cache post!)
+            h      {:host host :cache cache :ja ja}
+            expected 2]                                    ; two single-key swaps -> two host msgs -> two echoes
+        ;; host thread: validate + apply + echo, yielding a tick each time
+        (go-loop []
+          (when-let [^js msg (<! to-host)]
+            (<! (timeout 0))
+            (let [^js d @host
+                  ops   (bridge/build-edit-ops (LspDoc. d) (.-update msg))]
+              (when-not (= bridge/rejected ops)
+                (let [sorted  (sort-by (fn [op] (.offsetAt d (.-start ^js (:range op)))) > ops)
+                      changes (into-array (map (fn [op] #js{:range (:range op) :text (:content op)}) sorted))
+                      new-ver (inc (.-version d))]
+                  (reset! host (.update lsp/TextDocument d changes new-ver))
+                  (receive! #js{:type "update" :group "schematic"
+                                :version new-ver :update (.-update msg)}))))
+            (put! done-ch :ok)
+            (recur)))
+        ;; two concurrent writer threads
+        (go (<! (timeout 0)) (swap! ja assoc-in ["R1" :name] "R1x"))
+        (go (<! (timeout 0)) (swap! ja assoc-in ["C1" :name] "C1x"))
+        ;; wait for both edits to be applied, then assert
+        (go
+          (dotimes [_ expected] (<! done-ch))
+          (<! (timeout 0))
+          (is (valid-json? (host-text h)))
+          (is (converged? h) "disjoint concurrent writers must converge")
+          (is (= "R1x" (get-in (doc->state (host-text h)) ["R1" :name])))
+          (is (= "C1x" (get-in (doc->state (host-text h)) ["C1" :name])))
+          (close! to-host)
+          (done))))))

--- a/src/test/nyancad/mosaic/jsatom_test.cljs
+++ b/src/test/nyancad/mosaic/jsatom_test.cljs
@@ -68,30 +68,35 @@
          (protocol/make-json-atom "schematic" doc cache post! init-version)]
      {:bus bus :host host :cache cache :ja ja :receive! receive!})))
 
+(defn- apply-ops-to-host!
+  "Apply already-validated bridge ops to a real TextDocument, sorted descending
+   by offset so original-relative offsets stay valid (VSCode/jsonc apply edits
+   against the pre-edit document). Returns [new-doc new-version]."
+  [^js doc ops]
+  (let [sorted  (sort-by (fn [op] (.offsetAt doc (.-start ^js (:range op)))) > ops)
+        changes (into-array (map (fn [op] #js{:range (:range op) :text (:content op)}) sorted))
+        new-ver (inc (.-version doc))]
+    [(.update lsp/TextDocument doc changes new-ver) new-ver]))
+
 (defn- host-apply!
   "Mirror of extension.cljc/create-atom-channel's edit-queue + change-forward:
-   validate via the shared bridge, apply to the real TextDocument (descending by
-   offset so original-relative offsets stay valid), then enqueue the host->webview
-   echo tagged with the new document version. Returns :applied or :rejected."
+   validate via the shared bridge, apply to the real TextDocument, then enqueue
+   the host->webview echo tagged with the new document version. On reject, mirror
+   the extension by enqueueing an authoritative resync snapshot."
   [h ^js msg]
   (let [^js doc @(:host h)
         ops     (bridge/build-edit-ops (LspDoc. doc) (.-update msg))]
     (if (= bridge/rejected ops)
-      ;; mirror extension.cljc: on reject, send an authoritative resync snapshot
-      (do (swap! (:bus h) conj
-                 {:dir :webview
-                  :msg #js{:type "resync" :group (.-group msg)
-                           :version (.-version doc) :text (.getText doc)}})
-          :rejected)
-      (let [sorted  (sort-by (fn [op] (.offsetAt doc (.-start ^js (:range op)))) > ops)
-            changes (into-array (map (fn [op] #js{:range (:range op) :text (:content op)}) sorted))
-            new-ver (inc (.-version doc))]
-        (reset! (:host h) (.update lsp/TextDocument doc changes new-ver))
+      (swap! (:bus h) conj
+             {:dir :webview
+              :msg #js{:type "resync" :group (.-group msg)
+                       :version (.-version doc) :text (.getText doc)}})
+      (let [[doc' new-ver] (apply-ops-to-host! doc ops)]
+        (reset! (:host h) doc')
         (swap! (:bus h) conj
                {:dir :webview
                 :msg #js{:type "update" :group (.-group msg)
-                         :version new-ver :update (.-update msg)}})
-        :applied))))
+                         :version new-ver :update (.-update msg)}})))))
 
 (defn- external-edit!
   "Simulate an edit from outside the webview (user typing, another editor): replace
@@ -194,35 +199,18 @@
     (is (valid-json? (host-text h)))
     (is (not (contains? (doc->state (host-text h)) "C1")))))
 
-;; Falsy values: probe whether false / 0 / "" survive or get deleted.
+;; Falsy values: only nil should delete a key; false / 0 / "" must survive.
 ;; (Avoid :x/:y, which doc->state backfills and would mask a lost key.)
-(deftest write-false-survives
-  (let [h (make-harness (doc1))]
-    (swap! (:ja h) assoc-in ["R1" :mirror] false)
-    (drain! h)
-    (is (valid-json? (host-text h)))
-    (is (contains? (get (doc->state (host-text h)) "R1") :mirror)
-        "writing false must not delete the key")
-    (is (= false (get-in (doc->state (host-text h)) ["R1" :mirror])))
-    (is (converged? h))))
-
-(deftest write-zero-survives
-  (let [h (make-harness (doc1))]
-    (swap! (:ja h) assoc-in ["R1" :rotation] 0)
-    (drain! h)
-    (is (contains? (get (doc->state (host-text h)) "R1") :rotation)
-        "writing 0 must not delete the key")
-    (is (= 0 (get-in (doc->state (host-text h)) ["R1" :rotation])))
-    (is (converged? h))))
-
-(deftest write-empty-string-survives
-  (let [h (make-harness (doc1))]
-    (swap! (:ja h) assoc-in ["R1" :label] "")
-    (drain! h)
-    (is (contains? (get (doc->state (host-text h)) "R1") :label)
-        "writing \"\" must not delete the key")
-    (is (= "" (get-in (doc->state (host-text h)) ["R1" :label])))
-    (is (converged? h))))
+(deftest falsy-values-survive
+  (doseq [[k v] [[:mirror false] [:rotation 0] [:label ""]]]
+    (testing (str "writing " (pr-str v) " must not delete the key")
+      (let [h (make-harness (doc1))]
+        (swap! (:ja h) assoc-in ["R1" k] v)
+        (drain! h)
+        (is (valid-json? (host-text h)))
+        (is (contains? (get (doc->state (host-text h)) "R1") k))
+        (is (= v (get-in (doc->state (host-text h)) ["R1" k])))
+        (is (converged? h))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2. Batched-edit stacking
@@ -412,10 +400,8 @@
             (let [^js d @host
                   ops   (bridge/build-edit-ops (LspDoc. d) (.-update msg))]
               (when-not (= bridge/rejected ops)
-                (let [sorted  (sort-by (fn [op] (.offsetAt d (.-start ^js (:range op)))) > ops)
-                      changes (into-array (map (fn [op] #js{:range (:range op) :text (:content op)}) sorted))
-                      new-ver (inc (.-version d))]
-                  (reset! host (.update lsp/TextDocument d changes new-ver))
+                (let [[d' new-ver] (apply-ops-to-host! d ops)]
+                  (reset! host d')
                   (receive! #js{:type "update" :group "schematic"
                                 :version new-ver :update (.-update msg)}))))
             (put! done-ch :ok)


### PR DESCRIPTION
Add a Node-runnable harness that drives the jsatom webview<->extension-host
JSON edit protocol against Microsoft's real shared TextDocument model
(vscode-languageserver-textdocument), analogous to hipflask's PouchDB
conflict-resolution suite. To make the round-trip testable under the existing
:test build without Electron, extract the webview core into
nyancad.mosaic.jsatom.protocol (value->js, edit-message, changed-paths,
apply-echo, JsAtom, make-json-atom) and the host oldcontent validation into
nyancad.mosaic.jsatom.bridge/build-edit-ops behind an IHostDocument protocol;
jsatom.cljs and extension.cljc keep their VSCode wiring and delegate to these
shared cores.

The harness wires the real cores through an in-memory bus to a real
TextDocument (LspDoc), with a deterministic driver, a seeded interleaving
driver for concurrent-writer data races, and a core.async two-thread test. The
invariant after every scenario: the host stays valid JSON and host<->webview
converge.

Fixes the bugs the harness reproduced:
- value->js turned boolean false into js/undefined via (or (clj->js v) undef),
  silently deleting any field set to false (0 and "" happen to survive, being
  truthy under cljs `or`). Now only nil deletes.
- On an oldcontent-mismatch reject the host dropped the edit with only a log
  while the webview had already advanced optimistically, leaving it diverged
  forever. The host now sends an authoritative resync snapshot the webview
  adopts.
- The webview self-echo version guard assumed lockstep with the host document
  version but always started at 1; a document opened at version > 1 caused the
  webview to re-apply its own echo. The extension now injects the host document
  version so the guard is seeded correctly (NaN-safe fallback to 1).

Collaborative Work Statement:
- Originated from Pepijn's report that the VSCode extension sometimes corrupts
  the schematic JSON, and the observation that hipflask stresses conflict
  resolution while jsatom had no such coverage.
- Pepijn steered two key decisions: test against the real VSCode document model
  (chose the vscode-languageserver-textdocument in-Node approach over a heavier
  @vscode/test-electron harness, after weighing that Electron is harder to drive
  and worse at reproducing deterministic races), and "don't assume anything is
  broken before it reproduces" -- so the tests were written as behavioral
  invariants and run first, fixing only what actually failed.
- That rigor paid off: the assumed "0 and empty-string also get deleted" bug did
  NOT reproduce (cljs `or` treats them as truthy) -- only boolean false does --
  and the "reordered echo" scenario was dropped as unrealistic once we accounted
  for postMessage's ordered delivery.
- Pepijn also asked specifically for batched-edit stacking coverage and
  multiple async threads racing on one document, which shaped the stacking tests
  and the seeded-interleaving + core.async race drivers.
- Verified: full cljs suite green (597 assertions, 0 failures); the four
  production shadow-cljs builds (test, frontend, vscode-ext, vscode-webview)
  compile with no warnings. The extension-host resync/version-injection wiring
  is mirrored by construction against the harness model and warrants a manual
  F5 sanity check in a real extension host.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QYofecaBr2ZqWmWxxwSza2