### PR TITLE
Fix wire splitting races: disappearing segments and double undo checkpoints

### DIFF
--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -1078,15 +1078,16 @@
                     (iterate #(+ % (cm/sign width)) start))))
 
 (defn wire-locations [{:keys [x y rx ry variant]}]
-  (let [x2 (+ x rx) y2 (+ y ry)]
+  (let [x2 (+ x rx) y2 (+ y ry)
+        elbow? (and (not (zero? rx)) (not (zero? ry)))]
     [[[x y] [x2 y2]]  ; conn: start and end
      (case variant
        "hv" (concat (map #(vector % y) (exrange x rx))     ; horizontal leg
-                    [[x2 y]]                               ; corner
-                    (map #(vector x2 %) (exrange y ry)))   ; vertical leg
-       "vh" (concat (map #(vector x %) (exrange y ry))     ; vertical leg
-                    [[x y2]]                               ; corner
-                    (map #(vector % y2) (exrange x rx)))   ; horizontal leg
+                    (when elbow? [[x2 y]])                  ; corner (only for real bends)
+                    (map #(vector x2 %) (exrange y ry)))    ; vertical leg
+       "vh" (concat (map #(vector x %) (exrange y ry))      ; vertical leg
+                    (when elbow? [[x y2]])                   ; corner (only for real bends)
+                    (map #(vector % y2) (exrange x rx)))     ; horizontal leg
        ;; "d" or nil: straight or diagonal
        (cond
          (zero? rx) (map #(vector x %) (exrange y ry))     ; vertical
@@ -1536,19 +1537,6 @@
                    :when (not (shared-device? [x1 y1] [xn yn] seg-corner))]
                {:type "wire" :transform cm/IV :variant variant
                 :x x1 :y y1 :rx (- xn x1) :ry (- yn y1)})
-        ;; Segment ids must be DETERMINISTIC across clients. When two peers
-        ;; (or two tabs) split the same wire while syncing to a shared remote,
-        ;; a `gensym` id is minted independently on each, so the tail segments
-        ;; land as *distinct* documents that both survive replication —
-        ;; leaving duplicate/overlapping wires. Deriving each id from the wire
-        ;; id and the segment's start cell makes both peers emit the same
-        ;; documents, so CouchDB conflict resolution converges them to one.
-        ;;
-        ;; The first surviving segment reuses the original id: it keeps the
-        ;; wire's :name and, crucially, consumes the original document. (The
-        ;; old loop only reused the id for segment 0, so when that segment was
-        ;; dropped the original was never rewritten and lingered at full length
-        ;; alongside the new pieces — a double wire even without syncing.)
         seg-id (fn [{sx :x sy :y}] (str wirename "-split-" sx "-" sy))
         additions (zipmap (cons wirename (map seg-id (rest kept))) kept)]
     (if (seq kept)
@@ -1858,13 +1846,11 @@
         (same-tile? dev) (swap! ui assoc ; the dragged wire stayed at the same tile, exit
                                 ::staging nil
                                 ::dragging nil)
-        on-port (go (<! (commit-staged dev)) ; the wire landed on a port or wire, commit and exit
-                    (swap! ui assoc
-                           ::staging nil
-                           ::dragging nil))
-        :else (go
-                (<! (commit-staged dev)) ; commit and start new segment
-                (add-wire-segment [x y]))))))
+        on-port (do (swap! ui assoc ::staging nil ::dragging nil)
+                    (commit-staged dev))
+        :else (do (swap! ui assoc ::dragging nil)
+                  (go (<! (commit-staged dev))
+                      (add-wire-segment [x y])))))))
 
 (defn select-connected []
   (let [schem @schematic
@@ -2153,6 +2139,7 @@
           (commit-staged dev)
           (swap! ui assoc ::staging nil ::dragging nil)))
       (= (::tool @ui) ::eraser) (post-action!)
+      (= (::tool @ui) ::wire) nil
       :else (end-ui bg? selected dx dy))))
 
 (defn add-device [cell [x y] & args]

--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -1525,22 +1525,37 @@
                                     (or (not= "wire" (:type dev))
                                         (= seg-corner (wire-corner dev))))
                                  shared)))
-        wires (loop [w wirename
-                     [[x1 y1] & [[x2 y2] & _ :as other]] ordered
-                     schem {}]
-                (if other
-                  (let [seg-corner (case variant
-                                     "hv" [x2 y1]
-                                     "vh" [x1 y2]
-                                     nil)]
-                    (recur (name (gensym wirename)) other
-                           (if (shared-device? [x1 y1] [x2 y2] seg-corner)
-                             schem
-                             (assoc schem w
-                                    {:type "wire" :transform cm/IV :variant variant
-                                     :x x1 :y y1 :rx (- x2 x1) :ry (- y2 y1)}))))
-                  schem))]
-    (swap! schematic (partial merge-with merge) wires)))
+        ;; Surviving segments, in path order. Drop any segment already bridged
+        ;; by a device (or a co-cornered wire) — those points are connected
+        ;; without a wire of our own.
+        kept (for [[[x1 y1] [xn yn]] (partition 2 1 ordered)
+                   :let [seg-corner (case variant
+                                      "hv" [xn y1]
+                                      "vh" [x1 yn]
+                                      nil)]
+                   :when (not (shared-device? [x1 y1] [xn yn] seg-corner))]
+               {:type "wire" :transform cm/IV :variant variant
+                :x x1 :y y1 :rx (- xn x1) :ry (- yn y1)})
+        ;; Segment ids must be DETERMINISTIC across clients. When two peers
+        ;; (or two tabs) split the same wire while syncing to a shared remote,
+        ;; a `gensym` id is minted independently on each, so the tail segments
+        ;; land as *distinct* documents that both survive replication —
+        ;; leaving duplicate/overlapping wires. Deriving each id from the wire
+        ;; id and the segment's start cell makes both peers emit the same
+        ;; documents, so CouchDB conflict resolution converges them to one.
+        ;;
+        ;; The first surviving segment reuses the original id: it keeps the
+        ;; wire's :name and, crucially, consumes the original document. (The
+        ;; old loop only reused the id for segment 0, so when that segment was
+        ;; dropped the original was never rewritten and lingered at full length
+        ;; alongside the new pieces — a double wire even without syncing.)
+        seg-id (fn [{sx :x sy :y}] (str wirename "-split-" sx "-" sy))
+        additions (zipmap (cons wirename (map seg-id (rest kept))) kept)]
+    (if (seq kept)
+      (swap! schematic (partial merge-with merge) additions)
+      ;; Every segment was redundant: the whole wire is subsumed by devices,
+      ;; so remove it rather than leaving it floating.
+      (swap! schematic dissoc wirename))))
 
 
 (def last-coord (atom [0 0]))

--- a/src/test/nyancad/mosaic/editor/connectivity_test.cljc
+++ b/src/test/nyancad/mosaic/editor/connectivity_test.cljc
@@ -101,6 +101,18 @@
     (let [[_ body] (e/wire-locations {:x 0 :y 0 :rx 2 :ry 2 :variant "vh"})]
       (is (contains? (set body) [0 2]) "corner at (0, 2)"))))
 
+(deftest wire-locations-hv-degenerate-no-corner
+  (testing "hv with ry=0: corner coincides with endpoint, must not appear in body"
+    (let [[_ body] (e/wire-locations {:x 0 :y 0 :rx 3 :ry 0 :variant "hv"})]
+      (is (not (contains? (set body) [3 0]))
+          "degenerate corner at endpoint must be excluded from body"))))
+
+(deftest wire-locations-vh-degenerate-no-corner
+  (testing "vh with rx=0: corner coincides with endpoint, must not appear in body"
+    (let [[_ body] (e/wire-locations {:x 0 :y 0 :rx 0 :ry 3 :variant "vh"})]
+      (is (not (contains? (set body) [0 3]))
+          "degenerate corner at endpoint must be excluded from body"))))
+
 ;; ---------------------------------------------------------------------------
 ;; wire-corner — corner cell of an elbow wire, nil otherwise
 ;; ---------------------------------------------------------------------------
@@ -569,6 +581,29 @@
       (is (every? #(<= (abs (:rx %)) 2)
                   (for [[_ v] result :when (= "wire" (:type v))] v))
           "no surviving wire spans the whole original length"))))
+
+(deftest split-wire-hv-segment-survives-resplit
+  (testing "an hv wire split into a segment with ry=0 must not be re-flagged"
+    ;; Reproduce the reported bug: V1 at (8,4), GND port at (8,6), R2 at (5,3).
+    ;; Draw hv wire from V1.N (9,6) to R2.N (6,5) — passes through GND at (8,6).
+    ;; First split is correct. On the second post-action!, the shortened W1
+    ;; (rx=-1 ry=0 variant hv) must NOT be flagged for self-splitting.
+    (let [schem (sch ["V1" {:type "vsource" :x 8 :y 4 :transform [1 0 0 1 0 0] :name "V1"}]
+                     (port-doc "P1" 8 6 "GND")
+                     (resistor "R2" 5 3)
+                     ["W1" {:type "wire" :x 9 :y 6 :rx -3 :ry -1 :variant "hv"}])
+          result (split-once schem "W1")
+          wires  (into {} (filter (fn [[_ v]] (= "wire" (:type v))) result))]
+      (is (= 2 (count wires)) "first split produces two segments")
+      (is (contains? wires "W1") "original id reused")
+      (is (= {:x 9 :y 6 :rx -1 :ry 0} (select-keys (get wires "W1") [:x :y :rx :ry]))
+          "W1 is the shortened head segment")
+      ;; Now simulate the second post-action! with the already-split schematic.
+      ;; The shortened W1 must NOT appear in the wire-split-index.
+      (let [pt-idx2 (e/build-point-index result)
+            splits2 (e/build-wire-split-index result pt-idx2)]
+        (is (not (contains? splits2 "W1"))
+            "shortened W1 must not be re-flagged for splitting at its own endpoint")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Photonic model-defined ports

--- a/src/test/nyancad/mosaic/editor/connectivity_test.cljc
+++ b/src/test/nyancad/mosaic/editor/connectivity_test.cljc
@@ -506,6 +506,71 @@
       (is (empty? splits)))))
 
 ;; ---------------------------------------------------------------------------
+;; split-wire — the mutation that rewrites a wire into its pieces
+;; ---------------------------------------------------------------------------
+;; Contract: split a wire at the given cells into consecutive segments.
+;;   - The first surviving segment reuses the original id (so its :name and
+;;     document identity carry over); the rest get ids DERIVED from the wire
+;;     id + segment start cell, never a fresh gensym — so two clients splitting
+;;     the same wire while syncing produce identical documents that converge
+;;     under replication instead of duplicating.
+;;   - No original wire is ever left behind at full length.
+
+(defn- split-once
+  "Reset the shared schematic to `schem`, split `wirename` at its crossing
+   points, and return the resulting schematic map."
+  [schem wirename]
+  (reset! pform/schematic schem)
+  (let [pt-idx (e/build-point-index schem)
+        coords (get (e/build-wire-split-index schem pt-idx) wirename)]
+    (e/split-wire wirename coords pt-idx)
+    @pform/schematic))
+
+(deftest split-wire-reuses-original-and-adds-deterministic-tail
+  (testing "W1 crossing R1.N at (1,2) splits into original id + one derived id"
+    ;; R1 at (0,0): N at (1,2). W1 from (0,2)→(3,2) passes through (1,2).
+    (let [schem (sch (resistor "R1" 0 0)
+                     (wire "W1" 0 2 3 0))
+          result (split-once schem "W1")
+          wires  (into {} (filter (fn [[_ v]] (= "wire" (:type v))) result))]
+      (is (= 2 (count wires)) "exactly two segments, no duplicates")
+      (is (contains? wires "W1") "original id reused for the first segment")
+      (testing "first segment is (0,2)→(1,2)"
+        (is (= [0 2 1 0] ((juxt :x :y :rx :ry) (get wires "W1")))))
+      (testing "tail segment (1,2)→(3,2) has an id derived from the wire + start cell"
+        (let [tail (first (dissoc wires "W1"))]
+          (is (= "W1-split-1-2" (key tail)))
+          (is (= [1 2 2 0] ((juxt :x :y :rx :ry) (val tail)))))))))
+
+(deftest split-wire-is-deterministic-across-runs
+  (testing "splitting the same wire twice yields identical ids (convergent under sync)"
+    ;; Two independent clients both see W1 crossing R1.N and split it. The
+    ;; resulting document ids MUST match so replication merges them instead of
+    ;; accumulating duplicate tail wires. A gensym-based id would differ here.
+    (let [schem (sch (resistor "R1" 0 0)
+                     (resistor "R2" 0 4)  ; N at (1,6) — a second crossing
+                     (wire "W1" 0 2 5 0)) ; passes (1,2)=R1.N and ... only (1,2)
+          run1 (split-once schem "W1")
+          run2 (split-once schem "W1")
+          wire-ids (fn [m] (set (for [[k v] m :when (= "wire" (:type v))] k)))]
+      (is (= (wire-ids run1) (wire-ids run2))
+          "segment ids are identical across independent splits")
+      (is (contains? (wire-ids run1) "W1")
+          "original id is among them"))))
+
+(deftest split-wire-no-leftover-full-wire
+  (testing "the full-length original never survives alongside the pieces"
+    (let [schem (sch (resistor "R1" 0 0)
+                     (wire "W1" 0 2 3 0))
+          result (split-once schem "W1")]
+      ;; The rewritten W1 must be a piece (rx 1), not the original span (rx 3).
+      (is (= 1 (:rx (get result "W1")))
+          "W1 was shortened to its first segment, not left at full length")
+      (is (every? #(<= (abs (:rx %)) 2)
+                  (for [[_ v] result :when (= "wire" (:type v))] v))
+          "no surviving wire spans the whole original length"))))
+
+;; ---------------------------------------------------------------------------
 ;; Photonic model-defined ports
 ;; ---------------------------------------------------------------------------
 ;; Contract: when a photonic builtin has model ports in @modeldb,


### PR DESCRIPTION
## Summary

- **Deterministic split IDs** — when two peers split the same wire concurrently, they now produce identical segment documents (IDs derived from wire name + start cell), so CouchDB conflict resolution converges instead of leaving duplicate overlapping wires.
- **Degenerate corner fix** — `wire-locations` now guards corner-cell inclusion with an `elbow?` check. Previously, an "hv" wire with `ry=0` (straight after splitting) included its own endpoint as a body cell, causing `build-wire-split-index` to flag it for self-splitting → `shared-device?` dropped all segments → wire vanished.
- **Single post-action! per user action** — `add-wire` now clears `::dragging` synchronously before its async commit, preventing `drag-end` from re-committing the same wire on pointer-up. Eliminates duplicate undo checkpoints.

## Test plan

- [ ] Draw a wire from V1's bottom port through a GND symbol to R2's bottom port — both segments should survive
- [ ] Click-to-draw a wire (click start, move, click end on port) — single undo step
- [ ] Drag-to-draw a wire (press, hold, drag, release on port) — single undo step  
- [ ] Click-to-draw through empty space (click, move, click, move, click on port) — each segment gets one undo step
- [ ] Undo/redo after wire placement — each undo removes exactly one wire action
- [ ] Open two tabs on the same schematic, draw wires in both — no duplicate segments after sync