### PR TITLE
fix: paste grouping by prefix instead of type to prevent name collisions

### DIFF
--- a/src/main/nyancad/mosaic/editor.cljc
+++ b/src/main/nyancad/mosaic/editor.cljc
@@ -2397,13 +2397,13 @@
 
 (defn paste []
   (let [devmap (->> (get-in @local [(str "local" sep "clipboard") :data])
-                    (group-by :type)
-                    (map (fn [[typ devices]]
-                           (map (fn [name dev]
-                                  (let [id (str group sep name)
-                                        display-name (if (= typ "port") (:name dev) name)]
+                    (group-by #(cm/initial (:type %)))
+                    (map (fn [[_prefix devices]]
+                           (map (fn [nam dev]
+                                  (let [id (str group sep nam)
+                                        display-name (if (= (:type dev) "port") (:name dev) nam)]
                                     [id (assoc dev :name display-name)]))
-                                (make-names typ)
+                                (make-names (:type (first devices)))
                                 devices)))
                     (into {} cat))]
     (go


### PR DESCRIPTION
## Summary

Fixes a bug where pasting devices that share a SPICE prefix would silently overwrite each other. For example, pmos and nmos both use the "M" prefix, and npn/pnp both use "Q". Paste was grouping by device type and generating independent name sequences, causing collisions.

## Changes

- Group pasted devices by SPICE prefix instead of device type during name generation
- Ensures unique names across all devices with the same prefix, regardless of type